### PR TITLE
fix(provider-ollama): pin glm-5.3-flash cloud metadata floor to full 1M context window

### DIFF
--- a/.changeset/1787912326-monopi-provider-ollama.md
+++ b/.changeset/1787912326-monopi-provider-ollama.md
@@ -1,0 +1,7 @@
+---
+monopi-group: patch
+---
+
+# Pin glm-5.3-flash Ollama Cloud metadata floor to the full 1M context window
+
+glm-5.3-flash was missing from the Ollama Cloud metadata override catalog (the list stopped at glm-5.2). Discovery normally picks up the correct 1,048,576-token context length from the /api/show endpoint, but without a floor entry a stale credential cache or an API metadata gap would silently fall back to the 128k default and trigger premature compaction. Adds the authoritative floor (contextWindow 1,048,576, maxTokens 131,072, reasoning) plus tests covering fresh normalization and stale-cache repair.

--- a/packages/monopi__provider-ollama/models.ts
+++ b/packages/monopi__provider-ollama/models.ts
@@ -77,6 +77,7 @@ const OLLAMA_CLOUD_METADATA_OVERRIDES: readonly OllamaCloudMetadataOverride[] = 
 	{ id: "glm-5", contextWindow: 202_752, maxTokens: 131_072, reasoning: true, family: "glm5" },
 	{ id: "glm-5.1", contextWindow: 202_752, maxTokens: 131_072, reasoning: true, family: "glm5.1" },
 	{ id: "glm-5.2", contextWindow: 1_000_000, maxTokens: 131_072, reasoning: true, family: "glm5.2" },
+	{ id: "glm-5.3-flash", contextWindow: 1_048_576, maxTokens: 131_072, reasoning: true, family: "glm5_next" },
 	{ id: "gpt-oss:120b", contextWindow: 131_072, maxTokens: 16_384, reasoning: true, family: "gptoss" },
 	{ id: "gpt-oss:20b", contextWindow: 131_072, maxTokens: 16_384, reasoning: true, family: "gptoss" },
 	{ id: "kimi-k2.5", contextWindow: 262_144, maxTokens: 32_768, reasoning: true, family: "kimi-k2" },

--- a/packages/monopi__provider-ollama/tests/models.test.ts
+++ b/packages/monopi__provider-ollama/tests/models.test.ts
@@ -126,6 +126,37 @@ describe("ollama models", () => {
 		expect(model.reasoning).toBe(true);
 	});
 
+	it("pins glm-5.3-flash cloud metadata to the full 1M context window", () => {
+		const model = toOllamaModel({ id: "glm-5.3-flash:cloud", source: "cloud" });
+
+		expect(model.contextWindow).toBe(1_048_576);
+		expect(model.maxTokens).toBe(131_072);
+		expect(model.reasoning).toBe(true);
+	});
+
+	it("raises stale cached glm-5.3-flash metadata to the authoritative context floor", () => {
+		const models = getCredentialModels({
+			access: "a",
+			expires: Date.now() + 1000,
+			refresh: "r",
+			models: [
+				{
+					...toOllamaModel({ id: "glm-5.3-flash", source: "cloud" }),
+					contextWindow: 524_288,
+					maxTokens: 8_192,
+					reasoning: false,
+				},
+			],
+		});
+
+		expect(models[0]).toMatchObject({
+			contextWindow: 1_048_576,
+			id: "glm-5.3-flash",
+			maxTokens: 131_072,
+			reasoning: true,
+		});
+	});
+
 	it("sanitizes credential models with authoritative cloud metadata floors", () => {
 		const models = getCredentialModels({
 			access: "a",


### PR DESCRIPTION
## Summary

glm-5.3-flash was missing from the `OLLAMA_CLOUD_METADATA_OVERRIDES` catalog — the list stopped at `glm-5.2`. Live discovery currently picks up the correct `1,048,576`-token context length from Ollama's `/api/show` endpoint, but without an authoritative floor, a stale credential cache entry or an API metadata gap would silently fall back to the 128k `DEFAULT_CONTEXT_WINDOW`, causing pi to compact sessions ~8x earlier than the model actually supports.

This adds the floor entry, matching the catalog's "authoritative cloud metadata floors" contract (where `maxPositiveInteger` can only raise values):

- `contextWindow: 1_048_576` (verified against Ollama's `glm5_next.context_length`, the Ollama library page's 1M spec, and a live 955k-token prompt accepted by the cloud endpoint)
- `maxTokens: 131_072` (matches `OLLAMA_CLOUD_ZAI_REASONING_MAX_TOKENS` already applied to GLM cloud models)
- `family: "glm5_next"` (matches the family Ollama reports)

## Tests

- `pins glm-5.3-flash cloud metadata to the full 1M context window` — fresh normalization of the `:cloud`-suffixed id
- `raises stale cached glm-5.3-flash metadata to the authoritative context floor` — a stale cache reporting 524,288 is raised to the 1M floor, mirroring the existing glm-5.2 stale-cache test

## Verification

- `pnpm vitest run packages/monopi__provider-ollama`: 41 passed
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`: clean

---

Created on behalf of Ifiok Jr. (`@ifiokjr`) · model: codex (gpt-5.6-sol) · thinking: xhigh