### PR TITLE
fix(release): support npm 2FA one-time passwords in publish workflow

### DIFF
--- a/.changeset/publish-otp-support.md
+++ b/.changeset/publish-otp-support.md
@@ -1,0 +1,7 @@
+---
+monopi-group: patch
+---
+
+# Publish workflow supports npm 2FA one-time passwords
+
+`monochange run publish` now accepts `--otp <code>` and forwards it as `--otp` to `pnpm -r publish`, so npm 2FA publishes work from non-interactive terminals. Omitting the flag leaves the command unchanged.

--- a/monochange.toml
+++ b/monochange.toml
@@ -299,7 +299,9 @@ help_text = "Build and publish all public packages to npm. Pass --otp <code> whe
 inputs = [{ name = "otp", type = "string", help_text = "npm one-time password for two-factor authentication" }]
 steps = [
 	{ type = "Command", name = "build packages", command = "pnpm build" },
-	{ type = "Command", name = "publish packages", inputs = ["otp"], command = "pnpm -r publish --access public --no-git-checks {% if inputs.otp %}--otp {{ inputs.otp }}{% endif %}" },
+	{ type = "Command", name = "publish packages", inputs = [
+		"otp",
+	], command = "pnpm -r publish --access public --no-git-checks {% if inputs.otp %}--otp {{ inputs.otp }}{% endif %}" },
 ]
 
 [cli.get-version]

--- a/monochange.toml
+++ b/monochange.toml
@@ -295,10 +295,11 @@ steps = [
 ]
 
 [cli.publish]
-help_text = "Build and publish all public packages to npm"
+help_text = "Build and publish all public packages to npm. Pass --otp <code> when npm 2FA is enabled"
+inputs = [{ name = "otp", type = "string", help_text = "npm one-time password for two-factor authentication" }]
 steps = [
 	{ type = "Command", name = "build packages", command = "pnpm build" },
-	{ type = "Command", name = "publish packages", command = "pnpm -r publish --access public --no-git-checks" },
+	{ type = "Command", name = "publish packages", inputs = ["otp"], command = "pnpm -r publish --access public --no-git-checks {% if inputs.otp %}--otp {{ inputs.otp }}{% endif %}" },
 ]
 
 [cli.get-version]


### PR DESCRIPTION
## Summary

Fix the `monochange run publish` workflow so npm publishes work when 2FA is enabled.

### Problem

The previous edit added `inputs = [{ interactive = true }]` to the publish Command step, which fails config parsing ("did not match any variant of untagged enum RawInputs") — step inputs accept either a string array or an object map, not an array of tables. And even the corrected map form would only define a template variable: Command-step inputs are template data (confirmed by monochange's own test `command_inputs_do_not_implicitly_flow_into_steps`), so no input value can make the step interactive. monochange runs Command steps with captured stdio, so npm's OTP prompt can never appear.

### Fix

- Declare an optional `otp` string input on `[cli.publish]` (surfaces as `monochange run publish --otp <code>`).
- Forward it into the publish command and render `--otp <code>` conditionally with `{% if inputs.otp %}`, verified against the real binary: with the flag the command becomes `pnpm -r publish --access public --no-git-checks --otp <code>`; without it the command is unchanged.

### Verification

- `monochange step validate` and `mc check` pass.
- `monochange run publish --help` shows the `--otp` flag; dry-run executes cleanly.
- Scratch-workspace test with the real binary confirmed both rendering paths.

> Attribution: created on behalf of Ifiok Jr. (`@ifiokjr`), using the pi coding agent (claude-sonnet-4, high thinking).
