### PR TITLE
fix(release): run publish step interactively for npm 2FA

### DIFF
--- a/.changeset/publish-interactive-mode.md
+++ b/.changeset/publish-interactive-mode.md
@@ -1,0 +1,7 @@
+---
+monopi-group: patch
+---
+
+# Publish workflow supports interactive npm 2FA prompts
+
+`monochange run publish --interactive` runs the publish command with inherited stdio via the Command step's interactive input, so npm can prompt for 2FA and own the terminal. Without the flag the command runs non-interactively as before.

--- a/.changeset/publish-otp-support.md
+++ b/.changeset/publish-otp-support.md
@@ -1,7 +1,0 @@
----
-monopi-group: patch
----
-
-# Publish workflow supports npm 2FA one-time passwords
-
-`monochange run publish` now accepts `--otp <code>` and forwards it as `--otp` to `pnpm -r publish`, so npm 2FA publishes work from non-interactive terminals. Omitting the flag leaves the command unchanged.

--- a/monochange.toml
+++ b/monochange.toml
@@ -295,13 +295,11 @@ steps = [
 ]
 
 [cli.publish]
-help_text = "Build and publish all public packages to npm. Pass --otp <code> when npm 2FA is enabled"
-inputs = [{ name = "otp", type = "string", help_text = "npm one-time password for two-factor authentication" }]
+help_text = "Build and publish all public packages to npm. Pass --interactive so npm can prompt for 2FA"
+inputs = [{ name = "interactive", type = "boolean", default = false }]
 steps = [
 	{ type = "Command", name = "build packages", command = "pnpm build" },
-	{ type = "Command", name = "publish packages", inputs = [
-		"otp",
-	], command = "pnpm -r publish --access public --no-git-checks {% if inputs.otp %}--otp {{ inputs.otp }}{% endif %}" },
+	{ type = "Command", name = "publish packages", inputs = ["interactive"], command = "pnpm -r publish --access public --no-git-checks" },
 ]
 
 [cli.get-version]

--- a/monochange.toml
+++ b/monochange.toml
@@ -299,7 +299,9 @@ help_text = "Build and publish all public packages to npm. Pass --interactive so
 inputs = [{ name = "interactive", type = "boolean", default = false }]
 steps = [
 	{ type = "Command", name = "build packages", command = "pnpm build" },
-	{ type = "Command", name = "publish packages", inputs = ["interactive"], command = "pnpm -r publish --access public --no-git-checks" },
+	{ type = "Command", name = "publish packages", inputs = [
+		"interactive",
+	], command = "pnpm -r publish --access public --no-git-checks" },
 ]
 
 [cli.get-version]


### PR DESCRIPTION
## Summary

Switch the `monochange run publish` workflow to the Command step's interactive execution, replacing the `--otp` template approach from #376.

### How it works

The publish step forwards a declared boolean `interactive` input (default `false`) to the Command step. When passed, monochange's `execute_process_command` inherits stdio, pauses the spinner, and lets the command own the terminal, so npm can prompt for 2FA or open the browser. Without the flag the step runs non-interactively exactly as before.

```bash
monochange run publish --interactive
```

### Verification

- Doc reference (docs/src/reference/cli-steps/13-command.md) and `cli_runtime.rs` (`step_input_is_true(options.step_inputs, "interactive")` → inherited stdio in `execute_process_command`) confirm the runtime path.
- `monochange step validate` and `mc check` pass.
- `monochange run publish --help` surfaces the `--interactive` flag; dry-run executes cleanly.

> Attribution: created on behalf of Ifiok Jr. (`@ifiokjr`), using the pi coding agent (claude-sonnet-4, high thinking).
