### PR TITLE
fix(usage): show consumed quota percentage in the widget

### DIFF
--- a/.changeset/1788699120-monopi-extension-usage-tracker.md
+++ b/.changeset/1788699120-monopi-extension-usage-tracker.md
@@ -1,0 +1,7 @@
+---
+monopi-group: patch
+---
+
+# Show consumed quota percentage in the usage tracker widget
+
+The widget displayed the remaining budget (e.g. 16.3%) where provider dashboards display the consumed amount (e.g. 83.8% used), so Ollama Cloud (and every other provider's) quota state read inverted versus the web UI. The widget now renders percent used with the progress bar filling as the quota is consumed; the detailed report keeps showing both left and used.

--- a/packages/monopi__extension-usage-tracker/index.ts
+++ b/packages/monopi__extension-usage-tracker/index.ts
@@ -1388,7 +1388,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 		return lines;
 	}
 
-	/** Compact rate limit line for the widget. */
+	/** Compact rate limit line for the widget. Shows the consumed quota percentage, matching provider dashboards. */
 	function renderRateLimitsWidget(
 		theme: { fg: (c: string, t: string) => string },
 		provider: ProviderKey | null,
@@ -1400,14 +1400,15 @@ export default function usageTracker(pi: ExtensionAPI) {
 			}
 			const name = providerDisplayName(rl.provider);
 			const most = rl.windows.reduce((a, b) => (a.percentLeft < b.percentLeft ? a : b));
+			const usedPercent = clampPercent(100 - most.percentLeft);
 			const color = pctColor(most.percentLeft);
-			const bar = theme.fg(color, progressBar(most.percentLeft, 8));
+			const bar = theme.fg(color, progressBar(usedPercent, 8));
 			const reset = most.resetDescription ? theme.fg("dim", ` ↻${most.resetDescription}`) : "";
 			parts.push(
 				`${theme.fg("accent", name)} ${theme.fg(
 					"dim",
 					`${most.label}:`,
-				)} ${bar} ${theme.fg(color, `${most.percentLeft}%`)}${reset}`,
+				)} ${bar} ${theme.fg(color, `${usedPercent}% used`)}${reset}`,
 			);
 		}
 		return parts.join(theme.fg("dim", "  "));

--- a/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
+++ b/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
@@ -1036,6 +1036,52 @@ describe("usage-tracker extension", () => {
 			expect(text).toContain("remaining account limits are unknown");
 		});
 
+		it("shows consumed quota percentage in the widget", async () => {
+			process.env.OLLAMA_API_KEY = "test-key";
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("127.0.0.1:11434/v1/models")) {
+					return Promise.resolve(makeFetchResponse({ status: 503, ok: false }));
+				}
+				if (url.includes("ollama.com/api/usage")) {
+					return Promise.resolve(
+						makeFetchResponse({
+							body: {
+								limits: {
+									session: { usage: 0.005 },
+									weekly: { usage: 0.838 },
+								},
+							},
+						}),
+					);
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			const ollamaCtx = createMockCtx();
+			ollamaCtx.model = { id: "gpt-oss:20b", provider: "ollama-cloud" };
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ollamaCtx);
+
+			const widgetFactory = ollamaCtx._widgets.get("usage-tracker") as
+				| ((
+						tui: { requestRender: () => void },
+						theme: { fg: (_color: string, text: string) => string },
+				  ) => { render: (width: number) => string[] })
+				| undefined;
+			expect(widgetFactory).toBeTypeOf("function");
+
+			await runWithTimers(() => Promise.resolve());
+
+			const widget = widgetFactory?.({ requestRender: vi.fn() }, { fg: (_color: string, text: string) => text }).render(
+				160,
+			);
+			const widgetText = widget.join(" ");
+			expect(widgetText).toContain("Weekly (7d)");
+			expect(widgetText).toContain("83.8% used");
+			expect(widgetText).not.toContain("16.2%");
+		});
+
 		it("shows rate limit windows from Anthropic OAuth usage endpoint", async () => {
 			mockFetch.mockResolvedValue(
 				makeFetchResponse({
@@ -1769,7 +1815,7 @@ describe("usage-tracker extension", () => {
 			);
 			const rendered = component?.render(200).join("\n") ?? "";
 			expect(rendered).toContain("Anthropic");
-			expect(rendered).toContain("72%");
+			expect(rendered).toContain("28% used");
 		});
 
 		it("shows only the current provider in the widget when multiple providers have cached usage", async () => {
@@ -1818,7 +1864,7 @@ describe("usage-tracker extension", () => {
 			);
 			const rendered = component?.render(200).join("\n") ?? "";
 			expect(rendered).toContain("OpenAI");
-			expect(rendered).toContain("61%");
+			expect(rendered).toContain("39% used");
 			expect(rendered).not.toContain("Anthropic");
 		});
 


### PR DESCRIPTION
## Summary

The usage tracker widget displayed quota windows as the **remaining** budget — e.g. Ollama Cloud's weekly window showed `16.3%` when Ollama's dashboard shows `83.7% used`. The bare number read as "% used" and contradicted every provider's own web UI (Ollama, Claude, ChatGPT all present consumed quota).

The widget now renders the **consumed percentage** (`100 - percentLeft`, e.g. `83.8% used`), with the progress bar filling as quota is consumed instead of as it frees up. Internal semantics are unchanged: `RateWindow.percentLeft` remains the stored field, the widget's color coding still keys on how little remains, and the detailed `usage_report` keeps showing both conventions explicitly (`16.3% left (84% used)`).

## Example

Ollama Cloud with weekly usage at 83.8%:

- Before: `Ollama Weekly (7d): ████░░░░░░ 16.3%`
- After: `Ollama Weekly (7d): ████████░░ 83.8% used`

## Tests

- New: `shows consumed quota percentage in the widget` — widget renders `83.8% used` for weekly usage 0.838 and no longer shows the bare remaining figure
- Updated the two cached-widget tests (Anthropic 72% left → `28% used`; OpenAI 61% left → `39% used`) to the used convention

## Verification

- `pnpm vitest run packages/monopi__extension-usage-tracker`: 81 passed
- Full suite: 1479 passed, 8 skipped
- `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm monochange:validate`: clean
- Patch coverage (CI script, threshold 100): 2/2 changed executable lines covered

---

Created on behalf of Ifiok Jr. (`@ifiokjr`) · model: codex (gpt-5.6-sol) · thinking: xhigh