### PR TITLE
fix(usage): cap percentage precision to one decimal in widget and dashboard

### DIFF
--- a/.changeset/1788766292-monopi-group.md
+++ b/.changeset/1788766292-monopi-group.md
@@ -1,0 +1,7 @@
+---
+monopi-group: patch
+---
+
+# Cap usage percentage precision to one decimal
+
+The usage-tracker widget interpolated the consumed quota percentage into the status line as a raw float, so provider values like `33.32999999999999% used` could render with a dozen decimal places. Percentages in the widget line and the `/usage` dashboard rate-limit rows now display with at most one decimal place (`33.3% used`, `67% left`), matching the precision providers actually report.

--- a/packages/monopi__extension-usage-tracker/index.ts
+++ b/packages/monopi__extension-usage-tracker/index.ts
@@ -56,6 +56,7 @@ import {
 	fmtTokens,
 	formatPaceLeft,
 	formatPaceRight,
+	formatPercent,
 	pctColor,
 	progressBar,
 	truncateAnsi,
@@ -1279,7 +1280,9 @@ export default function usageTracker(pi: ExtensionAPI) {
 				const bar = progressBar(w.percentLeft, 20);
 				const usedPercent = clampPercent(100 - w.percentLeft);
 				const reset = w.resetDescription ? ` · resets ${w.resetDescription}` : "";
-				lines.push(`  ${w.label}: ${bar} ${w.percentLeft}% left (${usedPercent.toFixed(0)}% used)${reset}`);
+				lines.push(
+					`  ${w.label}: ${bar} ${formatPercent(w.percentLeft)}% left (${usedPercent.toFixed(0)}% used)${reset}`,
+				);
 
 				const pace = computeWindowPace(w);
 				if (pace) {
@@ -1293,7 +1296,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 			const most = windows[0];
 			if (most) {
-				lines.push(`  Most constrained: ${most.label} (${most.percentLeft}% left)`);
+				lines.push(`  Most constrained: ${most.label} (${formatPercent(most.percentLeft)}% left)`);
 			} else if (!rl.error) {
 				lines.push("  Windows: unavailable from current CLI output");
 			}
@@ -1340,7 +1343,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 				const color = pctColor(w.percentLeft);
 				const usedPercent = clampPercent(100 - w.percentLeft);
 				const bar = theme.fg(color, progressBar(w.percentLeft, 20));
-				const pct = theme.fg(color, `${w.percentLeft}% left`);
+				const pct = theme.fg(color, `${formatPercent(w.percentLeft)}% left`);
 				const used = theme.fg("dim", `(${usedPercent.toFixed(0)}% used)`);
 				const reset = w.resetDescription ? theme.fg("dim", ` · resets ${w.resetDescription}`) : "";
 				lines.push(`    ${theme.fg("accent", w.label.padEnd(15))}${bar} ${pct} ${used}${reset}`);
@@ -1361,7 +1364,9 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 			const most = windows[0];
 			if (most) {
-				lines.push(`    ${theme.fg("dim", `Most constrained: ${most.label} (${most.percentLeft}% left)`)}`);
+				lines.push(
+					`    ${theme.fg("dim", `Most constrained: ${most.label} (${formatPercent(most.percentLeft)}% left)`)}`,
+				);
 			} else if (!rl.error) {
 				lines.push(`    ${theme.fg("dim", "Windows unavailable from current CLI output")}`);
 			}
@@ -1408,7 +1413,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 				`${theme.fg("accent", name)} ${theme.fg(
 					"dim",
 					`${most.label}:`,
-				)} ${bar} ${theme.fg(color, `${usedPercent}% used`)}${reset}`,
+				)} ${bar} ${theme.fg(color, `${formatPercent(usedPercent)}% used`)}${reset}`,
 			);
 		}
 		return parts.join(theme.fg("dim", "  "));

--- a/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
+++ b/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
@@ -1082,6 +1082,39 @@ describe("usage-tracker extension", () => {
 			expect(widgetText).not.toContain("16.2%");
 		});
 
+		it("caps widget used-percent precision to one decimal", async () => {
+			mockFetch.mockResolvedValue(
+				makeFetchResponse({
+					body: {
+						five_hour: {
+							utilization: 16.666,
+							resets_at: new Date(Date.now() + 30_000).toISOString(),
+						},
+					},
+				}),
+			);
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			const widgetFactory = ctx._widgets.get("usage-tracker") as
+				| ((
+						tui: { requestRender: () => void },
+						theme: { fg: (_color: string, text: string) => string },
+				  ) => { render: (width: number) => string[] })
+				| undefined;
+			expect(widgetFactory).toBeTypeOf("function");
+
+			await runWithTimers(() => Promise.resolve());
+
+			const widget = widgetFactory?.({ requestRender: vi.fn() }, { fg: (_color: string, text: string) => text }).render(
+				160,
+			);
+			const widgetText = widget.join(" ");
+			expect(widgetText).toContain("16.7% used");
+			expect(widgetText).not.toContain("16.665");
+		});
+
 		it("shows rate limit windows from Anthropic OAuth usage endpoint", async () => {
 			mockFetch.mockResolvedValue(
 				makeFetchResponse({

--- a/packages/monopi__extension-usage-tracker/usage-tracker-formatting.ts
+++ b/packages/monopi__extension-usage-tracker/usage-tracker-formatting.ts
@@ -64,6 +64,11 @@ export function clampPercent(value: number): number {
 	return Math.max(0, Math.min(100, value));
 }
 
+/** Format a percentage with at most one decimal place (e.g. 33.33333 → 33.3, 50 → 50). */
+export function formatPercent(value: number): string {
+	return String(Number(value.toFixed(1)));
+}
+
 // Biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape codes use control chars by definition
 const ANSI_RE = /\x1B\[[0-9;]*[A-Za-z]|\x1B\][^\x07]*\x07|\x1B\(B/g;
 const RESET_COUNTDOWN_RE = /(\d+(?:\.\d+)?)\s*(weeks?|w|days?|d|hours?|hrs?|hr|h|minutes?|mins?|min|m)\b/g;


### PR DESCRIPTION
## Summary

The usage-tracker widget interpolated the consumed quota percentage as a **raw float**, so provider values could render as `33.32999999999999% used`. The root cause: the widget line added in #380 templated `usedPercent` directly, and the `100 - percentLeft` subtraction reintroduces float noise even when the provider reports clean values.

Fix:

- add `formatPercent()` (at most one decimal place — `33.33333` → `33.3`, `50` → `50`) in `usage-tracker-formatting.ts`
- use it for the widget's consumed-percentage line
- use it for the raw `% left` interpolations in the `/usage` dashboard rows (same bug class: provider-computed `remaining/limit` floats)

The existing `toFixed(0)` surfaces (used % in dashboard rows, pace) are unchanged, so dashboard strings like `(1% used)` are unaffected.

Includes a regression test: Anthropic `utilization: 16.666` must render `16.7% used`, never `16.665…`.

`pnpm exec vitest` (82 tests), `pnpm lint`, `pnpm typecheck`, and `pnpm format:check` pass locally.

Changeset: `.changeset/1788766292-monopi-group.md` (patch).

---

Created on behalf of Ifiok Jr. (`@ifiokjr`) — generated with GLM 5.3 Flash (thinking level: xhigh) via pi.