### PR TITLE
fix(usage): render percentages with two fixed decimal places

### DIFF
--- a/.changeset/1788768197-monopi-group.md
+++ b/.changeset/1788768197-monopi-group.md
@@ -1,0 +1,7 @@
+---
+monopi-group: patch
+---
+
+# Render usage percentages with two fixed decimal places
+
+Follow-up to the percentage precision fix: usage-tracker percentages now always render with exactly two decimal places (`50.00% used`, `75.00% left`) instead of the variable one-decimal formatting, so the number of decimals is fixed and float noise can never leak through.

--- a/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
+++ b/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
@@ -938,10 +938,10 @@ describe("usage-tracker extension", () => {
 			const text = result.content[0].text;
 			expect(text).toContain("Ollama Rate Limits:");
 			expect(text).toContain("Session (5h)");
-			expect(text).toContain("99.5% left");
+			expect(text).toContain("99.50% left");
 			expect(text).toContain("Weekly (7d)");
-			expect(text).toContain("17.3% left");
-			expect(text).toContain("75% left");
+			expect(text).toContain("17.30% left");
+			expect(text).toContain("75.00% left");
 			expect(text).toContain("billed the API-equivalent of $20.00 over the last 4 weeks");
 			expect(text).toContain("Cloud usage endpoint reachable.");
 		});
@@ -1078,11 +1078,11 @@ describe("usage-tracker extension", () => {
 			);
 			const widgetText = widget.join(" ");
 			expect(widgetText).toContain("Weekly (7d)");
-			expect(widgetText).toContain("83.8% used");
+			expect(widgetText).toContain("83.80% used");
 			expect(widgetText).not.toContain("16.2%");
 		});
 
-		it("caps widget used-percent precision to one decimal", async () => {
+		it("renders widget used-percent with two decimal places", async () => {
 			mockFetch.mockResolvedValue(
 				makeFetchResponse({
 					body: {
@@ -1111,7 +1111,7 @@ describe("usage-tracker extension", () => {
 				160,
 			);
 			const widgetText = widget.join(" ");
-			expect(widgetText).toContain("16.7% used");
+			expect(widgetText).toContain("16.67% used");
 			expect(widgetText).not.toContain("16.665");
 		});
 
@@ -1180,7 +1180,7 @@ describe("usage-tracker extension", () => {
 			const result = await runWithTimers(() => tool.execute("id", { format: "detailed" }, undefined, undefined, ctx));
 			const text = result.content[0].text;
 			expect(text).toContain("7-day Sonnet");
-			expect(text).toContain("99% left");
+			expect(text).toContain("99.00% left");
 			expect(text).toContain("(1% used)");
 		});
 
@@ -1220,7 +1220,7 @@ describe("usage-tracker extension", () => {
 			const text = result.content[0].text;
 
 			expect(text).toContain("5-hour");
-			expect(text).toContain("60% left");
+			expect(text).toContain("60.00% left");
 		});
 
 		it("restores cached Anthropic windows across restarts when the live probe is rate-limited", async () => {
@@ -1254,7 +1254,7 @@ describe("usage-tracker extension", () => {
 
 			expect(text).toContain("Anthropic Rate Limits:");
 			expect(text).toContain("7-day Sonnet");
-			expect(text).toContain("72% left");
+			expect(text).toContain("72.00% left");
 			expect(text).toContain("Showing last known window values");
 		});
 
@@ -1370,7 +1370,7 @@ describe("usage-tracker extension", () => {
 			const result = await runWithTimers(() => tool.execute("id", { format: "detailed" }, undefined, undefined, ctx));
 			const text = result.content[0].text;
 			expect(text).toContain("Subscription quota");
-			expect(text).toContain("100% left");
+			expect(text).toContain("100.00% left");
 			expect(text).toContain("Tier reports unlimited coding assistant capacity");
 		});
 
@@ -1848,7 +1848,7 @@ describe("usage-tracker extension", () => {
 			);
 			const rendered = component?.render(200).join("\n") ?? "";
 			expect(rendered).toContain("Anthropic");
-			expect(rendered).toContain("28% used");
+			expect(rendered).toContain("28.00% used");
 		});
 
 		it("shows only the current provider in the widget when multiple providers have cached usage", async () => {
@@ -1897,7 +1897,7 @@ describe("usage-tracker extension", () => {
 			);
 			const rendered = component?.render(200).join("\n") ?? "";
 			expect(rendered).toContain("OpenAI");
-			expect(rendered).toContain("39% used");
+			expect(rendered).toContain("39.00% used");
 			expect(rendered).not.toContain("Anthropic");
 		});
 

--- a/packages/monopi__extension-usage-tracker/usage-tracker-formatting.ts
+++ b/packages/monopi__extension-usage-tracker/usage-tracker-formatting.ts
@@ -64,9 +64,9 @@ export function clampPercent(value: number): number {
 	return Math.max(0, Math.min(100, value));
 }
 
-/** Format a percentage with at most one decimal place (e.g. 33.33333 → 33.3, 50 → 50). */
+/** Format a percentage with exactly two decimal places (e.g. 33.33333 → 33.33, 50 → 50.00). */
 export function formatPercent(value: number): string {
-	return String(Number(value.toFixed(1)));
+	return value.toFixed(2);
 }
 
 // Biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape codes use control chars by definition


### PR DESCRIPTION
## Summary

Follow-up to #383. Instead of the variable one-decimal formatting (`33.3`, `50`), usage-tracker percentages now render with **exactly two decimal places** via `toFixed(2)`:

- widget consumed quota line: `33.33% used`, `50.00% used`
- `/usage` dashboard rate-limit rows: `75.00% left`, `100.00% left`

The decimal count is now fixed, so float noise can never leak through regardless of what providers report.

All affected test expectations updated; 82 tests, lint, and format pass locally.

Changeset: `.changeset/1788768197-monopi-group.md` (patch).

---

Created on behalf of Ifiok Jr. (`@ifiokjr`) — generated with GLM 5.3 Flash (thinking level: xhigh) via pi.