### PR TITLE
fix(usage): trim trailing zeros from rendered percentages

### DIFF
--- a/.changeset/1788768467-monopi-group.md
+++ b/.changeset/1788768467-monopi-group.md
@@ -1,0 +1,7 @@
+---
+monopi-group: patch
+---
+
+# Trim trailing zeros from usage percentages
+
+Follow-up to the percentage precision fixes: usage-tracker percentages render with **at most** two decimal places — values that need fewer are shown without padding (`50% used`, `16.7% left`, `33.33% used`). Trailing zeros are trimmed, so nothing is ever rendered beyond two decimals, and clean values stay clean.

--- a/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
+++ b/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
@@ -938,10 +938,10 @@ describe("usage-tracker extension", () => {
 			const text = result.content[0].text;
 			expect(text).toContain("Ollama Rate Limits:");
 			expect(text).toContain("Session (5h)");
-			expect(text).toContain("99.50% left");
+			expect(text).toContain("99.5% left");
 			expect(text).toContain("Weekly (7d)");
-			expect(text).toContain("17.30% left");
-			expect(text).toContain("75.00% left");
+			expect(text).toContain("17.3% left");
+			expect(text).toContain("75% left");
 			expect(text).toContain("billed the API-equivalent of $20.00 over the last 4 weeks");
 			expect(text).toContain("Cloud usage endpoint reachable.");
 		});
@@ -1078,11 +1078,11 @@ describe("usage-tracker extension", () => {
 			);
 			const widgetText = widget.join(" ");
 			expect(widgetText).toContain("Weekly (7d)");
-			expect(widgetText).toContain("83.80% used");
+			expect(widgetText).toContain("83.8% used");
 			expect(widgetText).not.toContain("16.2%");
 		});
 
-		it("renders widget used-percent with two decimal places", async () => {
+		it("never renders widget used-percent with more than two decimal places", async () => {
 			mockFetch.mockResolvedValue(
 				makeFetchResponse({
 					body: {
@@ -1113,6 +1113,7 @@ describe("usage-tracker extension", () => {
 			const widgetText = widget.join(" ");
 			expect(widgetText).toContain("16.67% used");
 			expect(widgetText).not.toContain("16.665");
+			expect(widgetText).not.toContain(".00%");
 		});
 
 		it("shows rate limit windows from Anthropic OAuth usage endpoint", async () => {
@@ -1180,7 +1181,7 @@ describe("usage-tracker extension", () => {
 			const result = await runWithTimers(() => tool.execute("id", { format: "detailed" }, undefined, undefined, ctx));
 			const text = result.content[0].text;
 			expect(text).toContain("7-day Sonnet");
-			expect(text).toContain("99.00% left");
+			expect(text).toContain("99% left");
 			expect(text).toContain("(1% used)");
 		});
 
@@ -1220,7 +1221,7 @@ describe("usage-tracker extension", () => {
 			const text = result.content[0].text;
 
 			expect(text).toContain("5-hour");
-			expect(text).toContain("60.00% left");
+			expect(text).toContain("60% left");
 		});
 
 		it("restores cached Anthropic windows across restarts when the live probe is rate-limited", async () => {
@@ -1254,7 +1255,7 @@ describe("usage-tracker extension", () => {
 
 			expect(text).toContain("Anthropic Rate Limits:");
 			expect(text).toContain("7-day Sonnet");
-			expect(text).toContain("72.00% left");
+			expect(text).toContain("72% left");
 			expect(text).toContain("Showing last known window values");
 		});
 
@@ -1370,7 +1371,7 @@ describe("usage-tracker extension", () => {
 			const result = await runWithTimers(() => tool.execute("id", { format: "detailed" }, undefined, undefined, ctx));
 			const text = result.content[0].text;
 			expect(text).toContain("Subscription quota");
-			expect(text).toContain("100.00% left");
+			expect(text).toContain("100% left");
 			expect(text).toContain("Tier reports unlimited coding assistant capacity");
 		});
 
@@ -1848,7 +1849,7 @@ describe("usage-tracker extension", () => {
 			);
 			const rendered = component?.render(200).join("\n") ?? "";
 			expect(rendered).toContain("Anthropic");
-			expect(rendered).toContain("28.00% used");
+			expect(rendered).toContain("28% used");
 		});
 
 		it("shows only the current provider in the widget when multiple providers have cached usage", async () => {
@@ -1897,7 +1898,7 @@ describe("usage-tracker extension", () => {
 			);
 			const rendered = component?.render(200).join("\n") ?? "";
 			expect(rendered).toContain("OpenAI");
-			expect(rendered).toContain("39.00% used");
+			expect(rendered).toContain("39% used");
 			expect(rendered).not.toContain("Anthropic");
 		});
 

--- a/packages/monopi__extension-usage-tracker/usage-tracker-formatting.ts
+++ b/packages/monopi__extension-usage-tracker/usage-tracker-formatting.ts
@@ -64,9 +64,9 @@ export function clampPercent(value: number): number {
 	return Math.max(0, Math.min(100, value));
 }
 
-/** Format a percentage with exactly two decimal places (e.g. 33.33333 → 33.33, 50 → 50.00). */
+/** Format a percentage with at most two decimal places (trailing zeros trimmed; e.g. 33.33333 → 33.33, 16.7 → 16.7, 50 → 50). */
 export function formatPercent(value: number): string {
-	return value.toFixed(2);
+	return String(Number(value.toFixed(2)));
 }
 
 // Biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape codes use control chars by definition


### PR DESCRIPTION
## Summary

Follow-up to #384. Percentages render with **at most** two decimal places, not always two:

`formatPercent` = `toFixed(2)` + trailing-zero trim → `50`, `16.7`, `33.33`

- whole numbers render clean: `50% used`, `75% left`, `100% left`
- one-decimal values keep one: `16.7% used`, `99.5% left`
- noisy floats cap at two: `33.33333` → `33.33% used`, never more

Test expectations updated back to the trimmed forms, plus a `.00%`-padding regression guard in the widget precision test. 82 tests, lint, and format pass locally.

Changeset: `.changeset/1788768467-monopi-group.md` (patch).

---

Created on behalf of Ifiok Jr. (`@ifiokjr`) — generated with GLM 5.3 Flash (thinking level: xhigh) via pi.