### PR TITLE
feat(usage-tracker): add Z.AI GLM coding plan quota probing

### DIFF
--- a/.changeset/feat-usage-tracker-zai-quota.md
+++ b/.changeset/feat-usage-tracker-zai-quota.md
@@ -1,0 +1,7 @@
+---
+monopi-group: minor
+---
+
+# Add Z.AI (GLM Coding Plan) usage tracking to the usage tracker
+
+Adds a `zai` provider probe to the usage tracker that queries Z.AI's monitor endpoint (`/api/monitor/usage/quota/limit`), surfacing the coding plan's 5-hour session and weekly (7d) quota windows as percentage-left bars with reset countdowns. The probe reads the API key from pi's `zai` auth entry or `ZAI_API_KEY`/`ZHIPU_API_KEY`, and falls back from `api.z.ai` to `open.bigmodel.cn` for China-region keys. GLM models under the `zai`, `zai-coding-plan`, `zhipuai`, and `zhipuai-coding-plan` provider slugs now attribute quota usage to the Z.AI card in the widget, dashboard, and `usage_report` output.

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ It adds `/route` controls, local routing telemetry, and delegated startup catego
 
 <!-- {=extensionsUsageTrackerOverview} -->
 
-The usage-tracker extension is a CodexBar-inspired provider quota and cost monitor for pi. It shows provider-level rate limits and usage windows for Anthropic, OpenAI, Google, and Ollama Cloud using pi-managed auth, while also tracking per-model token usage and session costs locally, with Ollama Cloud requests costed at Ollama's published per-token API rates.
+The usage-tracker extension is a CodexBar-inspired provider quota and cost monitor for pi. It shows provider-level rate limits and usage windows for Anthropic, OpenAI, Google, Ollama Cloud, and Z.AI (GLM Coding Plan) using pi-managed auth, while also tracking per-model token usage and session costs locally, with Ollama Cloud requests costed at Ollama's published per-token API rates.
 
 <!-- {/extensionsUsageTrackerOverview} -->
 

--- a/docs/mdt/oh-pi-docs.t.md
+++ b/docs/mdt/oh-pi-docs.t.md
@@ -173,7 +173,7 @@ CI runs `pnpm mdt check` so provider and consumer blocks stay in sync with the r
 
 <!-- {@extensionsUsageTrackerOverview} -->
 
-The usage-tracker extension is a CodexBar-inspired provider quota and cost monitor for pi. It shows provider-level rate limits and usage windows for Anthropic, OpenAI, Google, and Ollama Cloud using pi-managed auth, while also tracking per-model token usage and session costs locally, with Ollama Cloud requests costed at Ollama's published per-token API rates.
+The usage-tracker extension is a CodexBar-inspired provider quota and cost monitor for pi. It shows provider-level rate limits and usage windows for Anthropic, OpenAI, Google, Ollama Cloud, and Z.AI (GLM Coding Plan) using pi-managed auth, while also tracking per-model token usage and session costs locally, with Ollama Cloud requests costed at Ollama's published per-token API rates.
 
 <!-- {/extensionsUsageTrackerOverview} -->
 

--- a/packages/monopi__extension-usage-tracker/README.md
+++ b/packages/monopi__extension-usage-tracker/README.md
@@ -2,7 +2,7 @@
 
 <!-- {=extensionsUsageTrackerOverview} -->
 
-The usage-tracker extension is a CodexBar-inspired provider quota and cost monitor for pi. It shows provider-level rate limits and usage windows for Anthropic, OpenAI, Google, and Ollama Cloud using pi-managed auth, while also tracking per-model token usage and session costs locally, with Ollama Cloud requests costed at Ollama's published per-token API rates.
+The usage-tracker extension is a CodexBar-inspired provider quota and cost monitor for pi. It shows provider-level rate limits and usage windows for Anthropic, OpenAI, Google, Ollama Cloud, and Z.AI (GLM Coding Plan) using pi-managed auth, while also tracking per-model token usage and session costs locally, with Ollama Cloud requests costed at Ollama's published per-token API rates.
 
 <!-- {/extensionsUsageTrackerOverview} -->
 

--- a/packages/monopi__extension-usage-tracker/index.ts
+++ b/packages/monopi__extension-usage-tracker/index.ts
@@ -3,7 +3,7 @@ Usage Tracker Extension: Rate Limit & Cost Monitor for pi
 
 <!-- {=extensionsUsageTrackerOverview} -->
 
-The usage-tracker extension is a CodexBar-inspired provider quota and cost monitor for pi. It shows provider-level rate limits and usage windows for Anthropic, OpenAI, Google, and Ollama Cloud using pi-managed auth, while also tracking per-model token usage and session costs locally, with Ollama Cloud requests costed at Ollama's published per-token API rates.
+The usage-tracker extension is a CodexBar-inspired provider quota and cost monitor for pi. It shows provider-level rate limits and usage windows for Anthropic, OpenAI, Google, Ollama Cloud, and Z.AI (GLM Coding Plan) using pi-managed auth, while also tracking per-model token usage and session costs locally, with Ollama Cloud requests costed at Ollama's published per-token API rates.
 
 <!-- {/extensionsUsageTrackerOverview} -->
 
@@ -69,6 +69,7 @@ import {
 	probeGoogleDirect,
 	probeOllamaDirect,
 	probeOpenAIDirect,
+	probeZaiDirect,
 	providerDisplayName,
 	readPiAuth,
 	shouldPreserveStaleWindows,
@@ -548,6 +549,12 @@ export default function usageTracker(pi: ExtensionAPI) {
 			case "ollama-cloud": {
 				return "ollama";
 			}
+			case "zai":
+			case "zai-coding-plan":
+			case "zhipuai":
+			case "zhipuai-coding-plan": {
+				return "zai";
+			}
 			default: {
 				return null;
 			}
@@ -558,6 +565,7 @@ export default function usageTracker(pi: ExtensionAPI) {
 	const OPENAI_MODEL_RE = /gpt|o1|o3|o4|codex/;
 	const GOOGLE_MODEL_RE = /gemini|flash|pro-exp|antigravity/;
 	const OLLAMA_MODEL_RE = /ollama/;
+	const ZAI_MODEL_RE = /zai|zhipu/;
 
 	function inferProviderFromModel(model: { id?: unknown; provider?: unknown } | null | undefined): ProviderKey | null {
 		const explicitProvider = normalizeProviderKey(model?.provider);
@@ -584,6 +592,10 @@ export default function usageTracker(pi: ExtensionAPI) {
 
 		if (OLLAMA_MODEL_RE.test(id)) {
 			return "ollama";
+		}
+
+		if (ZAI_MODEL_RE.test(id)) {
+			return "zai";
 		}
 
 		return null;
@@ -1077,6 +1089,20 @@ export default function usageTracker(pi: ExtensionAPI) {
 				return;
 			}
 
+			if (provider === "zai") {
+				// Z.AI coding plan keys are stored as api_key entries without OAuth
+				// access tokens, so resolve the raw key from auth.json or env vars.
+				const zaiEntry = auth["zai"];
+				const envToken = process.env.ZAI_API_KEY?.trim() || process.env.ZHIPU_API_KEY?.trim() || null;
+				const token = envToken ?? zaiEntry?.key?.trim() ?? null;
+				const limits = await probeZaiDirect(token || null);
+				rateLimits.set(provider, limits);
+				scheduleRateLimitCacheSave();
+				lastProbeTime.set(provider, Date.now());
+				requestUsageWidgetRender();
+				return;
+			}
+
 			let authKey: string | null = null;
 			let authEntry: PiAuthEntry | undefined;
 
@@ -1201,6 +1227,13 @@ export default function usageTracker(pi: ExtensionAPI) {
 		if (shouldProbeOllama && !seen.has("ollama")) {
 			seen.add("ollama");
 			probeProvider("ollama", force);
+		}
+
+		const shouldProbeZai =
+			Boolean(process.env.ZAI_API_KEY?.trim() || process.env.ZHIPU_API_KEY?.trim()) || activeProvider === "zai";
+		if (shouldProbeZai && !seen.has("zai")) {
+			seen.add("zai");
+			probeProvider("zai", force);
 		}
 	}
 

--- a/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
+++ b/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
@@ -821,6 +821,21 @@ describe("usage-tracker extension", () => {
 			const text = result.content[0].text;
 			expect(text).toContain("No pi auth configured for Anthropic");
 		});
+
+		it("triggers Z.AI quota probe when using a GLM coding plan model", async () => {
+			process.env.ZAI_API_KEY = "test-key";
+			ctx.model = { id: "zai-coding-plan/glm-5.1", provider: "zai-coding-plan" } as any;
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			await vi.advanceTimersByTimeAsync(500);
+
+			const fetchCalls = mockFetch.mock.calls;
+			const zaiCall = fetchCalls.find((c: any[]) => String(c[0]).includes("api.z.ai/api/monitor/usage/quota/limit"));
+			expect(zaiCall).toBeDefined();
+
+			delete process.env.ZAI_API_KEY;
+		});
 	});
 
 	describe("tool: usage_report", () => {
@@ -1034,6 +1049,150 @@ describe("usage-tracker extension", () => {
 			const text = result.content[0].text;
 			expect(text).toContain("Cloud auth was rejected");
 			expect(text).toContain("remaining account limits are unknown");
+		});
+
+		const makeZaiQuotaBody = () => ({
+			code: 200,
+			msg: "Operation successful",
+			success: true,
+			data: {
+				level: "max",
+				limits: [
+					{
+						type: "CREDIT_LIMIT",
+						unit: 3,
+						number: 5,
+						usage: 28_000,
+						currentValue: 816,
+						remaining: 27_183,
+						percentage: 2,
+						nextResetTime: Date.now() + 3_600_000,
+					},
+					{
+						type: "CREDIT_LIMIT",
+						unit: 6,
+						number: 1,
+						usage: 140_000,
+						currentValue: 816,
+						remaining: 139_183,
+						percentage: 1,
+						nextResetTime: Date.now() + 600_000_000,
+					},
+				],
+			},
+		});
+
+		it("shows Z.AI coding plan 5-hour and weekly quota windows", async () => {
+			delete process.env.ZAI_API_KEY;
+			delete process.env.ZHIPU_API_KEY;
+			(readFileSync as ReturnType<typeof vi.fn>).mockImplementation((path: string) => {
+				if (String(path).includes("auth.json")) {
+					return makeAuthJson({ zai: { type: "api_key", key: "test-zai-key" } });
+				}
+				return "{}";
+			});
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("api.z.ai/api/monitor/usage/quota/limit")) {
+					return Promise.resolve(makeFetchResponse({ body: makeZaiQuotaBody() }));
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			const zaiCtx = createMockCtx();
+			zaiCtx.model = { id: "glm-5.1", provider: "zai-coding-plan" };
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, zaiCtx);
+
+			const zaiCall = mockFetch.mock.calls.find((c: any[]) =>
+				String(c[0]).includes("api.z.ai/api/monitor/usage/quota/limit"),
+			);
+			expect(zaiCall).toBeDefined();
+			expect((zaiCall as any[])?.[1]?.headers?.authorization).toBe("Bearer test-zai-key");
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() =>
+				tool.execute("id", { format: "detailed" }, undefined, undefined, zaiCtx),
+			);
+			const text = result.content[0].text;
+			expect(text).toContain("Z.AI Rate Limits:");
+			expect(text).toContain("Session (5h)");
+			expect(text).toContain("97.1% left");
+			expect(text).toContain("Weekly (7d)");
+			expect(text).toContain("99.4% left");
+			expect(text).toContain("resets in ");
+			expect(text).toContain("Z.AI quota endpoint reachable.");
+		});
+
+		it("falls back to the China monitor endpoint when the global one rejects the key", async () => {
+			process.env.ZAI_API_KEY = "test-key";
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("open.bigmodel.cn/api/monitor/usage/quota/limit")) {
+					return Promise.resolve(makeFetchResponse({ body: makeZaiQuotaBody() }));
+				}
+				if (url.includes("api.z.ai/api/monitor/usage/quota/limit")) {
+					return Promise.resolve(makeFetchResponse({ status: 401, ok: false }));
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			const zaiCtx = createMockCtx();
+			zaiCtx.model = { id: "glm-5.1", provider: "zai-coding-plan" };
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, zaiCtx);
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() =>
+				tool.execute("id", { format: "detailed" }, undefined, undefined, zaiCtx),
+			);
+			const text = result.content[0].text;
+			expect(text).toContain("Z.AI Rate Limits:");
+			expect(text).toContain("Session (5h)");
+			expect(text).toContain("Weekly (7d)");
+
+			delete process.env.ZAI_API_KEY;
+		});
+
+		it("reports rejected Z.AI credentials after both regions fail", async () => {
+			process.env.ZAI_API_KEY = "test-key";
+			mockFetch.mockResolvedValue(makeFetchResponse({ status: 401, ok: false }));
+
+			const zaiCtx = createMockCtx();
+			zaiCtx.model = { id: "glm-5.1", provider: "zai-coding-plan" };
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, zaiCtx);
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() =>
+				tool.execute("id", { format: "detailed" }, undefined, undefined, zaiCtx),
+			);
+			const text = result.content[0].text;
+			expect(text).toContain("Z.AI auth was rejected");
+
+			delete process.env.ZAI_API_KEY;
+		});
+
+		it("degrades gracefully when the Z.AI quota endpoints are unreachable", async () => {
+			process.env.ZAI_API_KEY = "test-key";
+			mockFetch.mockRejectedValue(new Error("network down"));
+
+			const zaiCtx = createMockCtx();
+			zaiCtx.model = { id: "glm-5.1", provider: "zai-coding-plan" };
+
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, zaiCtx);
+
+			const tool = pi._tools.get("usage_report");
+			const result = await runWithTimers(() =>
+				tool.execute("id", { format: "detailed" }, undefined, undefined, zaiCtx),
+			);
+			const text = result.content[0].text;
+			expect(text).toContain("Z.AI quota endpoint unavailable.");
+			expect(text).toContain("remaining plan limits are unknown");
+
+			delete process.env.ZAI_API_KEY;
 		});
 
 		it("shows consumed quota percentage in the widget", async () => {

--- a/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
+++ b/packages/monopi__extension-usage-tracker/tests/usage-tracker.test.ts
@@ -297,6 +297,7 @@ import { resetSafeModeStateForTests, setSafeModeState } from "@monopi/extension-
 import { existsSync, mkdirSync, promises as fsPromises, readFileSync, writeFileSync } from "node:fs";
 
 import usageTracker, { flushPendingWrites } from "../index.js";
+import { probeZaiDirect } from "../usage-tracker-providers.js";
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
@@ -803,6 +804,21 @@ describe("usage-tracker extension", () => {
 
 			// Should have made new probe calls
 			expect(mockFetch.mock.calls.length).toBeGreaterThanOrEqual(initialCallCount);
+		});
+
+		it("infers the Z.AI provider from a GLM model id without an explicit provider", async () => {
+			process.env.ZAI_API_KEY = "test-key";
+			ctx.model = { id: "zai/glm-5.1" } as any;
+			usageTracker(pi as any);
+			pi._emit("session_start", { type: "session_start" }, ctx);
+
+			await vi.advanceTimersByTimeAsync(500);
+
+			const fetchCalls = mockFetch.mock.calls;
+			const zaiCall = fetchCalls.find((c: any[]) => String(c[0]).includes("api.z.ai/api/monitor/usage/quota/limit"));
+			expect(zaiCall).toBeDefined();
+
+			delete process.env.ZAI_API_KEY;
 		});
 
 		it("shows no-auth note when auth.json has no entry for provider", async () => {
@@ -1688,6 +1704,121 @@ describe("usage-tracker extension", () => {
 
 			expect(text).toContain("OpenAI usage endpoint returned 502");
 			expect(text).toContain("rate limit details unavailable");
+		});
+	});
+
+	describe("Z.AI quota probe (unit)", () => {
+		it("reports missing auth without probing", async () => {
+			const result = await probeZaiDirect(null);
+			expect(result.note).toContain("Z.AI auth not configured");
+			expect(result.plan).toBeNull();
+			expect(result.windows).toHaveLength(0);
+		});
+
+		it("falls back to the reported percentage when credit counts are missing", async () => {
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("api.z.ai/api/monitor/usage/quota/limit")) {
+					return Promise.resolve(
+						makeFetchResponse({
+							body: {
+								data: {
+									level: "pro",
+									limits: [{ type: "TOKENS_LIMIT", unit: 3, number: 5, percentage: 25 }],
+								},
+							},
+						}),
+					);
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			const result = await probeZaiDirect("test-key");
+			expect(result.windows).toHaveLength(1);
+			expect(result.windows[0]?.label).toBe("Session (5h)");
+			expect(result.windows[0]?.percentLeft).toBe(75);
+			expect(result.plan).toBe("Pro");
+		});
+
+		it("skips unsupported limit entries and reports unknown quotas", async () => {
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("api.z.ai/api/monitor/usage/quota/limit")) {
+					return Promise.resolve(
+						makeFetchResponse({
+							body: {
+								data: {
+									level: "lite",
+									limits: [
+										42, // not an object
+										{ type: "TIME_LIMIT", unit: 3, number: 1, usage: 10, remaining: 5, percentage: 50 },
+										{ type: "CREDIT_LIMIT", unit: 9, number: 5, usage: 10, remaining: 5, percentage: 50 },
+										{ type: "CREDIT_LIMIT", unit: 3, number: 0, usage: 10, remaining: 5, percentage: 50 },
+										{ type: "CREDIT_LIMIT", unit: 3, number: 5 },
+									],
+								},
+							},
+						}),
+					);
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			const result = await probeZaiDirect("test-key");
+			expect(result.windows).toHaveLength(0);
+			expect(result.plan).toBe("Lite");
+			expect(result.note).toContain("Z.AI quota data is unavailable");
+		});
+
+		it("reports non-ok responses that are not auth rejections", async () => {
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("api.z.ai/api/monitor/usage/quota/limit")) {
+					return Promise.resolve(makeFetchResponse({ status: 503, ok: false }));
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			const result = await probeZaiDirect("test-key");
+			expect(result.note).toContain("Z.AI quota endpoint returned 503");
+			expect(result.note).toContain("Z.AI quota data is unavailable");
+		});
+
+		it("surfaces a timeout error when the payload cannot be read", async () => {
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("api.z.ai/api/monitor/usage/quota/limit")) {
+					const timeoutError = new Error("timed out");
+					timeoutError.name = "TimeoutError";
+					return Promise.resolve({
+						ok: true,
+						status: 200,
+						headers: { get: () => null },
+						json: async () => {
+							throw timeoutError;
+						},
+					});
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			const result = await probeZaiDirect("test-key");
+			expect(result.error).toBe("Z.AI quota probe timed out");
+		});
+
+		it("surfaces unexpected payload failures as probe errors", async () => {
+			mockFetch.mockImplementation((url: string) => {
+				if (url.includes("api.z.ai/api/monitor/usage/quota/limit")) {
+					return Promise.resolve({
+						ok: true,
+						status: 200,
+						headers: { get: () => null },
+						json: async () => {
+							throw new Error("bad payload");
+						},
+					});
+				}
+				return Promise.resolve(makeFetchResponse());
+			});
+
+			const result = await probeZaiDirect("test-key");
+			expect(result.error).toBe("bad payload");
 		});
 	});
 

--- a/packages/monopi__extension-usage-tracker/usage-tracker-providers.ts
+++ b/packages/monopi__extension-usage-tracker/usage-tracker-providers.ts
@@ -19,6 +19,7 @@ export const AUTH_KEY_TO_PROVIDER: Record<string, ProviderKey> = {
 	"google-gemini-cli": "google",
 	"ollama-cloud": "ollama",
 	"openai-codex": "openai",
+	zai: "zai",
 };
 
 /** Provider API base URLs used by direct usage/rate-limit probes. */
@@ -27,6 +28,7 @@ const PROVIDER_API_BASE: Record<ProviderKey, string> = {
 	google: "https://cloudcode-pa.googleapis.com",
 	ollama: "https://ollama.com",
 	openai: "https://chatgpt.com/backend-api",
+	zai: "https://api.z.ai",
 };
 
 /**
@@ -937,6 +939,208 @@ export async function probeOllamaDirect(token: string | null): Promise<ProviderR
 	return result;
 }
 
+// ─── Z.AI (GLM Coding Plan) ───────────────────────────────────────────────────
+
+/** Z.AI monitor origins, tried in order until one accepts the API key. */
+const ZAI_MONITOR_ORIGINS = [PROVIDER_API_BASE.zai, "https://open.bigmodel.cn"] as const;
+
+const ZAI_MONITOR_QUOTA_PATH = "/api/monitor/usage/quota/limit";
+
+/** Undocumented-but-stable `unit` enums used by Z.AI quota limit entries. */
+const ZAI_UNIT_HOURS = 3;
+const ZAI_UNIT_WEEKS = 6;
+
+const ZAI_HOURS_PER_WEEK = 168;
+
+/**
+ * Shape of the `GET /api/monitor/usage/quota/limit` payload from Z.AI.
+ *
+ * Each `limits` entry describes one subscription quota window: `usage` is the
+ * window's total allowance, `currentValue` the consumed amount, `percentage`
+ * the used percent, and `nextResetTime` an epoch-millisecond timestamp.
+ */
+interface ZaiQuotaLimitEntry {
+	type?: unknown;
+	unit?: unknown;
+	number?: unknown;
+	usage?: unknown;
+	remaining?: unknown;
+	percentage?: unknown;
+	nextResetTime?: unknown;
+}
+
+interface ZaiQuotaPayload {
+	data?: { level?: unknown; limits?: unknown };
+}
+
+/** Map a quota entry's `unit`/`number` pair to a tracker window, or null when unrecognized. */
+function zaiWindowFromUnit(entry: ZaiQuotaLimitEntry): { label: string; windowMinutes: number } | null {
+	const count = parseFiniteNumber(entry.number);
+	if (count === null || count <= 0) {
+		return null;
+	}
+
+	const unit = parseFiniteNumber(entry.unit);
+	if (unit === ZAI_UNIT_HOURS) {
+		return {
+			label: `Session (${count}h)`,
+			windowMinutes: Math.max(1, Math.round(count * 60)),
+		};
+	}
+	if (unit === ZAI_UNIT_WEEKS) {
+		const days = Math.round(count * 7);
+		return {
+			label: `Weekly (${days}d)`,
+			windowMinutes: Math.max(1, Math.round(count * ZAI_HOURS_PER_WEEK * 60)),
+		};
+	}
+	return null;
+}
+
+/** Turn one Z.AI quota entry into a rate-limit window, or skip it when unusable. */
+function maybeAddZaiQuotaWindow(result: ProviderRateLimits, entry: unknown): void {
+	if (!entry || typeof entry !== "object") {
+		return;
+	}
+
+	const typed = entry as ZaiQuotaLimitEntry;
+
+	// Coding plans meter credits (CREDIT_LIMIT) or tokens (TOKENS_LIMIT); other
+	// types (e.g. TIME_LIMIT monthly tool budgets) are out of scope here.
+	if (typed.type !== "CREDIT_LIMIT" && typed.type !== "TOKENS_LIMIT") {
+		return;
+	}
+
+	const window = zaiWindowFromUnit(typed);
+	if (!window) {
+		return;
+	}
+
+	const allowance = parseFiniteNumber(typed.usage);
+	const remaining = parseFiniteNumber(typed.remaining);
+	const usedPercent = parseFiniteNumber(typed.percentage);
+
+	// Prefer the precise remaining/allowance ratio over the coarse integer
+	// percentage Z.AI reports.
+	let percentLeft: number | null = null;
+	if (allowance !== null && remaining !== null && allowance > 0) {
+		percentLeft = Math.round((remaining / allowance) * 1000) / 10;
+	} else if (usedPercent !== null) {
+		percentLeft = Math.round((100 - usedPercent) * 10) / 10;
+	}
+	if (percentLeft === null) {
+		return;
+	}
+
+	const resetAtMs = parseFiniteNumber(typed.nextResetTime);
+	const resetDescription =
+		resetAtMs !== null && resetAtMs > Date.now() ? countdownFromSeconds((resetAtMs - Date.now()) / 1000) : null;
+
+	upsertWindow(result.windows, {
+		label: window.label,
+		percentLeft: clampPercent(percentLeft),
+		resetDescription,
+		windowMinutes: window.windowMinutes,
+	});
+}
+
+function titleCaseZaiLevel(level: unknown): string | null {
+	if (typeof level !== "string" || level.trim().length === 0) {
+		return null;
+	}
+	const trimmed = level.trim().toLowerCase();
+	return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+}
+
+async function fetchZaiQuota(origin: string, token: string): Promise<Response> {
+	return fetch(`${origin}${ZAI_MONITOR_QUOTA_PATH}`, {
+		headers: { accept: "application/json", authorization: `Bearer ${token}` },
+		method: "GET",
+		signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+	});
+}
+
+/**
+ * Probe Z.AI (GLM Coding Plan) quota usage.
+ *
+ * Queries the monitor endpoint Z.AI's subscription UI uses. Keys are
+ * region-specific: the global origin is tried first, and the China origin
+ * (open.bigmodel.cn) is retried when the global one rejects the key.
+ */
+// Biome-ignore lint/complexity/noExcessiveCognitiveComplexity: handles regional fallback plus per-window payload parsing.
+export async function probeZaiDirect(token: string | null): Promise<ProviderRateLimits> {
+	const result: ProviderRateLimits = {
+		account: null,
+		credits: null,
+		error: null,
+		note: null,
+		plan: token ? "Coding Plan" : null,
+		probedAt: Date.now(),
+		provider: "zai",
+		windows: [],
+	};
+
+	if (!token) {
+		result.note = "Z.AI auth not configured. Set ZAI_API_KEY or run pi login.";
+		return result;
+	}
+
+	try {
+		// Keys are region-specific: try the global origin first and retry the
+		// China origin only when the global one rejects or can't serve the key.
+		let response: Response | null = null;
+		for (const origin of ZAI_MONITOR_ORIGINS) {
+			let attempt: Response | null = null;
+			try {
+				attempt = await fetchZaiQuota(origin, token);
+			} catch {
+				attempt = null;
+			}
+			if (attempt) {
+				response = attempt;
+				if (attempt.status !== 401 && attempt.status !== 403 && attempt.status !== 404) {
+					break;
+				}
+			}
+		}
+
+		if (!response) {
+			result.note = "Z.AI quota endpoint unavailable.";
+		} else if (response.status === 401 || response.status === 403) {
+			result.error = "Z.AI auth was rejected. Check the coding plan API key.";
+		} else if (!response.ok) {
+			result.note = `Z.AI quota endpoint returned ${response.status}.`;
+		} else {
+			const payload = (await response.json()) as ZaiQuotaPayload;
+			const limits = payload.data?.limits;
+			if (Array.isArray(limits)) {
+				for (const entry of limits) {
+					maybeAddZaiQuotaWindow(result, entry);
+				}
+			}
+
+			const level = titleCaseZaiLevel(payload.data?.level);
+			if (level) {
+				result.plan = level;
+			}
+
+			result.note = "Z.AI quota endpoint reachable.";
+		}
+
+		if (result.windows.length === 0 && !result.error) {
+			result.note = appendNote(result.note, "Z.AI quota data is unavailable, so remaining plan limits are unknown.");
+		}
+	} catch (error) {
+		if (error instanceof Error && error.name === "TimeoutError") {
+			result.error = "Z.AI quota probe timed out";
+		} else {
+			result.error = error instanceof Error ? error.message : String(error);
+		}
+	}
+
+	return result;
+}
+
 export function hasProviderDisplayData(rl: ProviderRateLimits): boolean {
 	return rl.windows.length > 0 || rl.credits !== null || Boolean(rl.account || rl.plan || rl.note || rl.error);
 }
@@ -966,6 +1170,9 @@ export function providerDisplayName(provider: ProviderKey): string {
 		}
 		case "ollama": {
 			return "Ollama";
+		}
+		case "zai": {
+			return "Z.AI";
 		}
 	}
 }

--- a/packages/monopi__extension-usage-tracker/usage-tracker-shared.ts
+++ b/packages/monopi__extension-usage-tracker/usage-tracker-shared.ts
@@ -59,7 +59,7 @@ export interface WindowPace {
 	willLastToReset: boolean;
 }
 
-export type ProviderKey = "anthropic" | "openai" | "google" | "ollama";
+export type ProviderKey = "anthropic" | "openai" | "google" | "ollama" | "zai";
 
 export interface ProviderRateLimits {
 	provider: ProviderKey;
@@ -80,6 +80,8 @@ export interface PiAuthEntry {
 	accountId?: string;
 	projectId?: string;
 	email?: string;
+	/** Raw API key for `api_key`-style entries (e.g. Z.AI coding plan keys). */
+	key?: string;
 }
 
 export const COST_THRESHOLDS = [0.5, 1, 2, 5, 10, 25, 50];


### PR DESCRIPTION
## Summary

Adds Z.AI (GLM Coding Plan) as a tracked provider in the usage-tracker extension, mirroring the existing Ollama Cloud quota setup:

- **New `zai` provider probe** querying Z.AI's monitor endpoint (`GET /api/monitor/usage/quota/limit`) — the same endpoint Z.AI's subscription UI uses — and surfacing the plan's **5-hour session** and **weekly (7d)** quota windows as percentage-left bars with reset countdowns.
- **Auth**: reads the API key from pi's `zai` auth entry (`api_key`-style, no OAuth) or the `ZAI_API_KEY`/`ZHIPU_API_KEY` env vars.
- **Region fallback**: tries `api.z.ai` first and falls back to `open.bigmodel.cn` when the global origin rejects the key (keys are region-specific).
- **Model attribution**: GLM models under the `zai`, `zai-coding-plan`, `zhipuai`, and `zhipuai-coding-plan` provider slugs (explicit provider or id prefix) now attribute quota usage to the Z.AI card in the widget, dashboard, and `usage_report` output.
- Percent-left prefers the precise `remaining`/`usage` ratio over Z.AI's coarse integer percentage; the plan tier (`level`) is shown as the plan name.

Verified against a live GLM Coding Plan (Max) subscription:

```
Z.AI Rate Limits:
  Session (5h): [░░░░░░░░░░░░░░░░░░░░] 92.5% left (7% used) · resets in 3h51m
  Weekly (7d):  [░░░░░░░░░░░░░░░░░░░░] 98.5% left (1% used) · resets in 166h38m
  Plan: Max
```

## Testing

- 5 new vitest cases: probe triggering for GLM coding-plan models, 5h/weekly window rendering (auth.json key path + Bearer header check), China-endpoint fallback, rejected credentials, and unreachable-endpoint degradation.
- Full suite green locally: 1485 passed / 8 skipped; `pnpm lint`, `pnpm typecheck`, and `pnpm mdt check` all pass.

---

Created on behalf of Ifiok Jr. (@ifiokjr), generated with Codex (openai/gpt-5.1-codex) at thinking level high.