### PR TITLE
feat(adaptive-routing): add quota failover for mirrored models

### DIFF
--- a/.changeset/feat-adaptive-routing-quota-failover.md
+++ b/.changeset/feat-adaptive-routing-quota-failover.md
@@ -1,0 +1,7 @@
+---
+monopi-group: minor
+---
+
+# Add quota failover for mirrored models to adaptive routing
+
+Adds a `quotaFailover` section to adaptive routing that switches to the *same* model on another provider when the active provider's quota runs out. Mirror sets (e.g. `ollama-cloud/glm-5.3-flash` ↔ `zai/glm-5.3-flash` ↔ `opencode-go/glm-5.3-flash`) are declared explicitly in config or auto-derived from identical model ids across providers, and the resolver picks the healthiest mirror once the active provider's most-constrained window (5h or weekly, from the usage tracker's broadcast) drops to `switchBelowPct`, returning home when it recovers. Switches apply at turn start in `auto` mode (notify-only in `shadow`), respect manual `/route lock`, and a new `/route failover` command shows each set's live quota and the current decision. Also fixes the `usage:limits` consumer to read `windows[].percentLeft` (with `probedAt` staleness), which previously left provider quota permanently "unknown" to the router.

--- a/docs/feature-catalog.md
+++ b/docs/feature-catalog.md
@@ -310,6 +310,7 @@ Purpose:
 - shadow-routing or auto-routing decisions for prompts
 - delegated startup categories for subagents when no explicit model override is set
 - telemetry and explainability around why a model/provider was picked
+- quota failover to identical models on other providers when the active provider's window is exhausted
 
 Primary commands:
 
@@ -318,6 +319,7 @@ Primary commands:
 - `/route shadow`
 - `/route off`
 - `/route explain`
+- `/route failover`
 - `/route assignments`
 - `/route why <category|role-override> [task text]`
 - `/route stats`

--- a/packages/monopi__adaptive-routing/README.md
+++ b/packages/monopi__adaptive-routing/README.md
@@ -16,6 +16,32 @@ This package is intentionally separate from `@monopi/monopi` so users can opt in
 - persists local routing telemetry
 - exposes delegated routing categories that subagents can read from startup config
 - lets you describe provider assignments by category instead of hard-coding Anthropic/OpenAI defaults into agents
+- switches to an identical model on another provider when the active provider's quota runs out (`quotaFailover`)
+
+## Quota failover
+
+When the active model belongs to a mirror set and its provider's most-constrained quota window (5h or weekly, whichever is lower — from the usage tracker's `usage:limits` broadcast) drops to `switchBelowPct`, adaptive routing switches to the same model on a provider that still has at least `requireMirrorAbovePct` remaining, and returns to the home entry once it recovers. Switches apply at turn start in `auto` mode; `shadow` only suggests. A manual `/route lock` pins the model and suspends failover.
+
+```json
+{
+	"quotaFailover": {
+		"enabled": true,
+		"autoMirror": false,
+		"mirrorSets": [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash", "opencode-go/glm-5.3-flash"]],
+		"switchBelowPct": 5,
+		"requireMirrorAbovePct": 20,
+		"returnHome": true,
+		"onUnknownQuota": "stay",
+		"staleAfterMinutes": 10
+	}
+}
+```
+
+- `mirrorSets` — ordered sets of full model ids; the first entry is home. With `autoMirror: true`, additional sets are derived automatically from identical model ids across authenticated providers.
+- `switchBelowPct` / `requireMirrorAbovePct` — the exhaustion cliff and the minimum quota a mirror must have.
+- `onUnknownQuota: "stay"` — never fail over on missing or stale quota snapshots (`staleAfterMinutes`).
+
+Inspect the current state with `/route failover`.
 
 ## Config
 

--- a/packages/monopi__adaptive-routing/adaptive-routing.test.ts
+++ b/packages/monopi__adaptive-routing/adaptive-routing.test.ts
@@ -53,6 +53,7 @@ vi.mock("@earendil-works/pi-ai/compat", () => ({
 	})),
 }));
 
+import { DEFAULT_QUOTA_FAILOVER_CONFIG } from "./defaults.js";
 import adaptiveRoutingExtension, { resolveDelegatedAssignmentModel } from "./index.js";
 
 function sampleModel(provider: string, id: string, name = id) {
@@ -408,6 +409,7 @@ describe("adaptive routing extension", () => {
 				stickyTurns: 1,
 				telemetry: { mode: "local", privacy: "minimal" },
 				models: { ranked: [], excluded: [] },
+				quotaFailover: { ...DEFAULT_QUOTA_FAILOVER_CONFIG },
 				intents: {},
 				taskClasses: {},
 				providerReserves: {},
@@ -448,6 +450,7 @@ describe("adaptive routing extension", () => {
 				stickyTurns: 1,
 				telemetry: { mode: "local", privacy: "minimal" },
 				models: { ranked: [], excluded: [] },
+				quotaFailover: { ...DEFAULT_QUOTA_FAILOVER_CONFIG },
 				intents: {},
 				taskClasses: {},
 				providerReserves: {},
@@ -512,5 +515,400 @@ describe("adaptive routing extension", () => {
 				expect.stringContaining("openai/gpt-5.4"),
 			]),
 		);
+	});
+
+	const glmModel = (provider: string) => sampleModel(provider, "glm-5.3-flash");
+
+	function emitUsageLimits(harness: ReturnType<typeof createExtensionHarness>, providers: Record<string, unknown>) {
+		harness.pi.events.emit("usage:limits", {
+			providers,
+			sessionCost: 0,
+			rolling30dCost: 0,
+			perModel: {},
+			perSource: {},
+		});
+	}
+
+	const healthyMirrorQuota = {
+		"ollama-cloud": {
+			provider: "ollama",
+			probedAt: Date.now(),
+			windows: [
+				{ label: "Session (5h)", percentLeft: 0.4, resetDescription: "in 3h", windowMinutes: 300 },
+				{ label: "Weekly (7d)", percentLeft: 12, resetDescription: "in 2d", windowMinutes: 10_080 },
+			],
+		},
+		zai: {
+			provider: "zai",
+			probedAt: Date.now(),
+			windows: [{ label: "Session (5h)", percentLeft: 97.1, resetDescription: "in 2h", windowMinutes: 300 }],
+		},
+	};
+
+	it("switches to a mirror provider when the active model's quota is exhausted", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify(
+				{
+					mode: "auto",
+					models: { ranked: ["ollama-cloud/glm-5.3-flash"] },
+					quotaFailover: {
+						enabled: true,
+						autoMirror: false,
+						mirrorSets: [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash", "opencode-go/glm-5.3-flash"]],
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = glmModel("ollama-cloud") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [glmModel("ollama-cloud"), glmModel("zai"), glmModel("opencode-go")],
+			getApiKeyForProvider: async () => "key",
+		} as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		emitUsageLimits(harness, healthyMirrorQuota);
+
+		await harness.emitAsync(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Continue the refactor.", systemPrompt: "system" },
+			harness.ctx,
+		);
+
+		expect(harness.ctx.model).toMatchObject({ id: "glm-5.3-flash", provider: "zai" });
+		expect(
+			harness.notifications.some((n) => n.msg.includes("Quota failover:") && n.msg.includes("zai/glm-5.3-flash")),
+		).toBe(true);
+	});
+
+	it("suggests but does not switch in shadow mode", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify(
+				{
+					mode: "shadow",
+					quotaFailover: {
+						enabled: true,
+						autoMirror: false,
+						mirrorSets: [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash"]],
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = glmModel("ollama-cloud") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [glmModel("ollama-cloud"), glmModel("zai")],
+			getApiKeyForProvider: async () => "key",
+		} as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		emitUsageLimits(harness, healthyMirrorQuota);
+
+		await harness.emitAsync(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Continue the refactor.", systemPrompt: "system" },
+			harness.ctx,
+		);
+
+		expect(harness.ctx.model).toMatchObject({ id: "glm-5.3-flash", provider: "ollama-cloud" });
+		expect(
+			harness.notifications.some(
+				(n) => n.msg.includes("Quota failover suggestion:") && n.msg.includes("zai/glm-5.3-flash"),
+			),
+		).toBe(true);
+	});
+
+	it("keeps the current model when no quota data has arrived", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify(
+				{
+					mode: "auto",
+					models: { ranked: ["ollama-cloud/glm-5.3-flash"] },
+					quotaFailover: { enabled: true, mirrorSets: [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash"]] },
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = glmModel("ollama-cloud") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [glmModel("ollama-cloud"), glmModel("zai")],
+			getApiKeyForProvider: async () => "key",
+		} as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+
+		await harness.emitAsync(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Continue the refactor.", systemPrompt: "system" },
+			harness.ctx,
+		);
+
+		expect(harness.ctx.model).toMatchObject({ id: "glm-5.3-flash", provider: "ollama-cloud" });
+	});
+
+	it("renders mirror set status in /route failover", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify(
+				{
+					mode: "auto",
+					quotaFailover: {
+						enabled: true,
+						autoMirror: false,
+						mirrorSets: [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash", "opencode-go/glm-5.3-flash"]],
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = glmModel("ollama-cloud") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [glmModel("ollama-cloud"), glmModel("zai"), glmModel("opencode-go")],
+			getApiKeyForProvider: async () => "key",
+		} as never;
+
+		let renderedLines: string[] = [];
+		harness.ctx.ui.custom = vi.fn(async (factory) => {
+			const component = factory({ requestRender() {} }, null, null, () => undefined);
+			renderedLines = component.render(120);
+			return null;
+		}) as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		emitUsageLimits(harness, healthyMirrorQuota);
+
+		await harness.commands.get("route failover")?.handler?.("", harness.ctx as never);
+
+		expect(renderedLines).toEqual(
+			expect.arrayContaining([
+				expect.stringContaining("Quota failover: switch ≤5%"),
+				expect.stringContaining("ollama-cloud/glm-5.3-flash — 0.4% left · Session (5h) ← active"),
+				expect.stringContaining("zai/glm-5.3-flash — 97.1% left"),
+				expect.stringContaining("opencode-go/glm-5.3-flash — quota unknown"),
+				expect.stringContaining("Decision now: switch → zai/glm-5.3-flash (exhausted)"),
+			]),
+		);
+	});
+
+	it("returns home once the home provider recovers and clears failover state on manual switch", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify(
+				{
+					mode: "auto",
+					models: { ranked: ["zai/glm-5.3-flash"] },
+					quotaFailover: {
+						enabled: true,
+						autoMirror: false,
+						mirrorSets: [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash"]],
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = glmModel("zai") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [glmModel("ollama-cloud"), glmModel("zai")],
+			getApiKeyForProvider: async () => "key",
+		} as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		emitUsageLimits(harness, {
+			"ollama-cloud": {
+				probedAt: Date.now(),
+				windows: [{ label: "Session (5h)", percentLeft: 80, resetDescription: "in 1h", windowMinutes: 300 }],
+			},
+			zai: {
+				probedAt: Date.now(),
+				windows: [{ label: "Session (5h)", percentLeft: 40, resetDescription: "in 2h", windowMinutes: 300 }],
+			},
+		});
+
+		await harness.emitAsync(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Continue the refactor.", systemPrompt: "system" },
+			harness.ctx,
+		);
+
+		expect(harness.ctx.model).toMatchObject({ id: "glm-5.3-flash", provider: "ollama-cloud" });
+		expect(harness.notifications.some((n) => n.msg.includes("recovered"))).toBe(true);
+		expect(harness.statusMap.get("adaptive-routing")).toContain("\u27f2 ollama-cloud/glm-5.3-flash");
+
+		// A manual model switch clears the failover marker.
+		await harness.emitAsync("model_select", { model: { id: "glm-5.3-flash", provider: "zai" } }, harness.ctx);
+		expect(harness.statusMap.get("adaptive-routing")).not.toContain("\u27f2");
+	});
+
+	it("keeps a healthy model and reports no failover", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify(
+				{
+					mode: "auto",
+					models: { ranked: ["ollama-cloud/glm-5.3-flash"] },
+					quotaFailover: {
+						enabled: true,
+						autoMirror: false,
+						mirrorSets: [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash"]],
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = glmModel("ollama-cloud") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [glmModel("ollama-cloud"), glmModel("zai")],
+			getApiKeyForProvider: async () => "key",
+		} as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		emitUsageLimits(harness, {
+			"ollama-cloud": {
+				probedAt: Date.now(),
+				windows: [{ label: "Session (5h)", percentLeft: 42, resetDescription: "in 1h", windowMinutes: 300 }],
+			},
+		});
+
+		await harness.emitAsync(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Continue the refactor.", systemPrompt: "system" },
+			harness.ctx,
+		);
+
+		expect(harness.ctx.model).toMatchObject({ id: "glm-5.3-flash", provider: "ollama-cloud" });
+		expect(harness.notifications.some((n) => n.msg.startsWith("Quota failover:"))).toBe(false);
+	});
+
+	it("reports failures when the mirror switch is rejected", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify(
+				{
+					mode: "auto",
+					models: { ranked: ["ollama-cloud/glm-5.3-flash"] },
+					quotaFailover: {
+						enabled: true,
+						autoMirror: false,
+						mirrorSets: [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash"]],
+					},
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = glmModel("ollama-cloud") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [glmModel("ollama-cloud"), glmModel("zai")],
+			getApiKeyForProvider: async () => "key",
+		} as never;
+		harness.pi.setModel = async () => false;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		emitUsageLimits(harness, healthyMirrorQuota);
+
+		await harness.emitAsync(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Continue the refactor.", systemPrompt: "system" },
+			harness.ctx,
+		);
+
+		expect(harness.notifications.some((n) => n.msg.includes("Failed to switch to zai/glm-5.3-flash"))).toBe(true);
+	});
+
+	it("ignores malformed usage payload entries", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify({ mode: "shadow" }, null, 2)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = glmModel("zai") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [glmModel("zai")],
+			getApiKeyForProvider: async () => "key",
+		} as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		emitUsageLimits(harness, {
+			empty: { windows: [] },
+			junk: { windows: [42, { percentLeft: "not-a-number" }, { label: "no-pct" }] },
+			staleOnly: { stale: true },
+			weird: "not-an-object",
+		});
+
+		await harness.emitAsync(
+			"before_agent_start",
+			{ type: "before_agent_start", prompt: "Continue the refactor.", systemPrompt: "system" },
+			harness.ctx,
+		);
+
+		expect(harness.ctx.model).toMatchObject({ id: "glm-5.3-flash", provider: "zai" });
+	});
+
+	it("renders the disabled notice in /route failover", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify({ mode: "auto" }, null, 2)}\n`,
+		);
+		const harness = createExtensionHarness();
+
+		let renderedLines: string[] = [];
+		harness.ctx.ui.custom = vi.fn(async (factory) => {
+			const component = factory({ requestRender() {} }, null, null, () => undefined);
+			renderedLines = component.render(120);
+			return null;
+		}) as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		await harness.commands.get("route failover")?.handler?.("", harness.ctx as never);
+
+		expect(renderedLines).toEqual(expect.arrayContaining([expect.stringContaining("Quota failover: disabled")]));
+	});
+
+	it("renders the no-sets notice in /route failover", async () => {
+		writeFileSync(
+			join(tempAgentDir, "extensions", "adaptive-routing", "config.json"),
+			`${JSON.stringify(
+				{
+					mode: "auto",
+					quotaFailover: { enabled: true, autoMirror: false, mirrorSets: [["a/x", "b/x"]] },
+				},
+				null,
+				2,
+			)}\n`,
+		);
+		const harness = createExtensionHarness();
+		harness.ctx.model = glmModel("zai") as never;
+		harness.ctx.modelRegistry = {
+			getAvailable: () => [glmModel("zai")],
+			getApiKeyForProvider: async () => "key",
+		} as never;
+
+		let renderedLines: string[] = [];
+		harness.ctx.ui.custom = vi.fn(async (factory) => {
+			const component = factory({ requestRender() {} }, null, null, () => undefined);
+			renderedLines = component.render(120);
+			return null;
+		}) as never;
+
+		adaptiveRoutingExtension(harness.pi as never);
+		await harness.commands.get("route failover")?.handler?.("", harness.ctx as never);
+
+		expect(renderedLines).toEqual(expect.arrayContaining([expect.stringContaining("No mirror sets resolved")]));
 	});
 });

--- a/packages/monopi__adaptive-routing/config.ts
+++ b/packages/monopi__adaptive-routing/config.ts
@@ -18,6 +18,8 @@ import type {
 	FallbackGroupPolicy,
 	IntentRoutingPolicy,
 	ProviderReservePolicy,
+	QuotaFailoverConfig,
+	QuotaFailoverUnknownPolicy,
 	RouteIntent,
 	RouteThinkingLevel,
 	RouteTier,
@@ -46,6 +48,7 @@ const DELEGATED_TASK_PROFILES = new Set<DelegatedTaskProfile>(["design", "planni
 const ROUTING_MODES = new Set<AdaptiveRoutingMode>(["off", "shadow", "auto"]);
 const TELEMETRY_MODES = new Set<AdaptiveRoutingTelemetryMode>(["off", "local", "export"]);
 const PRIVACY_LEVELS = new Set<AdaptiveRoutingPrivacyLevel>(["minimal", "redacted", "full-local"]);
+const QUOTA_FAILOVER_UNKNOWN_POLICIES = new Set<QuotaFailoverUnknownPolicy>(["stay", "switch"]);
 const warnedConfigMessages = new Set<string>();
 
 function warnAdaptiveRoutingConfig(configPath: string, message: string): void {
@@ -95,6 +98,7 @@ function normalizeAdaptiveRoutingConfigWithWarnings(raw: unknown): NormalizedCon
 			mode: normalizeMode(cfg.mode, fallback.mode, warnings, "mode"),
 			models: normalizeModelPreferences(cfg.models, fallback.models, warnings),
 			providerReserves: normalizeProviderReserves(cfg.providerReserves, fallback.providerReserves),
+			quotaFailover: normalizeQuotaFailover(cfg.quotaFailover, fallback.quotaFailover, warnings),
 			routerModels: normalizeStringArray(cfg.routerModels, fallback.routerModels),
 			stickyTurns: normalizeStickyTurns(cfg.stickyTurns, fallback.stickyTurns),
 			taskClasses: normalizeTaskClasses(cfg.taskClasses, fallback.taskClasses),
@@ -158,6 +162,56 @@ function normalizeModelPreferences(
 	return {
 		excluded: normalizeStringArray(cfg.excluded, fallback.excluded),
 		ranked: normalizeStringArray(cfg.ranked, fallback.ranked),
+	};
+}
+
+function normalizeQuotaFailover(
+	value: unknown,
+	fallback: QuotaFailoverConfig,
+	warnings?: string[],
+): QuotaFailoverConfig {
+	if (!value || typeof value !== "object") {
+		if (value !== undefined) {
+			warnings?.push("Skipped invalid quotaFailover section; using fallback.");
+		}
+		return { ...fallback, mirrorSets: fallback.mirrorSets.map((set) => [...set]) };
+	}
+	const cfg = value as Record<string, unknown>;
+
+	const mirrorSets: string[][] = [];
+	if (Array.isArray(cfg.mirrorSets)) {
+		for (const entry of cfg.mirrorSets) {
+			if (!Array.isArray(entry)) {
+				warnings?.push("Skipped a non-array quotaFailover.mirrorSets entry.");
+				continue;
+			}
+			const ids = entry
+				.filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+				.map((id) => id.trim());
+			if (ids.length < 2) {
+				warnings?.push("Skipped a quotaFailover.mirrorSets entry with fewer than two model ids.");
+				continue;
+			}
+			mirrorSets.push(ids);
+		}
+	}
+
+	return {
+		autoMirror: typeof cfg.autoMirror === "boolean" ? cfg.autoMirror : fallback.autoMirror,
+		enabled: typeof cfg.enabled === "boolean" ? cfg.enabled : fallback.enabled,
+		mirrorSets,
+		onUnknownQuota:
+			typeof cfg.onUnknownQuota === "string" &&
+			QUOTA_FAILOVER_UNKNOWN_POLICIES.has(cfg.onUnknownQuota as QuotaFailoverUnknownPolicy)
+				? (cfg.onUnknownQuota as QuotaFailoverUnknownPolicy)
+				: fallback.onUnknownQuota,
+		requireMirrorAbovePct: normalizePercent(cfg.requireMirrorAbovePct, fallback.requireMirrorAbovePct),
+		returnHome: typeof cfg.returnHome === "boolean" ? cfg.returnHome : fallback.returnHome,
+		staleAfterMinutes:
+			typeof cfg.staleAfterMinutes === "number" && Number.isFinite(cfg.staleAfterMinutes) && cfg.staleAfterMinutes >= 1
+				? cfg.staleAfterMinutes
+				: fallback.staleAfterMinutes,
+		switchBelowPct: normalizePercent(cfg.switchBelowPct, fallback.switchBelowPct),
 	};
 }
 

--- a/packages/monopi__adaptive-routing/defaults.ts
+++ b/packages/monopi__adaptive-routing/defaults.ts
@@ -3,6 +3,7 @@ import type {
 	AdaptiveRoutingExplanationCode,
 	FallbackGroupPolicy,
 	IntentRoutingPolicy,
+	QuotaFailoverConfig,
 	RouteIntent,
 } from "./types.js";
 
@@ -87,6 +88,17 @@ export const DEFAULT_FALLBACK_GROUPS: Record<string, FallbackGroupPolicy> = {
 	},
 };
 
+export const DEFAULT_QUOTA_FAILOVER_CONFIG: QuotaFailoverConfig = {
+	autoMirror: true,
+	enabled: false,
+	mirrorSets: [],
+	onUnknownQuota: "stay",
+	requireMirrorAbovePct: 20,
+	returnHome: true,
+	staleAfterMinutes: 10,
+	switchBelowPct: 5,
+};
+
 export const DEFAULT_ADAPTIVE_ROUTING_CONFIG: AdaptiveRoutingConfig = {
 	delegatedModelSelection: {
 		allowSmallContextForSmallTasks: true,
@@ -154,6 +166,7 @@ export const DEFAULT_ADAPTIVE_ROUTING_CONFIG: AdaptiveRoutingConfig = {
 		excluded: [],
 		ranked: [],
 	},
+	quotaFailover: { ...DEFAULT_QUOTA_FAILOVER_CONFIG },
 	providerReserves: {
 		"cursor-agent": {
 			allowOverrideForPeak: true,

--- a/packages/monopi__adaptive-routing/index.ts
+++ b/packages/monopi__adaptive-routing/index.ts
@@ -4,7 +4,10 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@e
 import type {
 	AdaptiveRoutingMode,
 	AdaptiveRoutingState,
+	NormalizedRouteCandidate,
 	ProviderUsageState,
+	QuotaFailoverAction,
+	QuotaFailoverConfig,
 	RouteDecision,
 	RouteFeedbackCategory,
 	RouteThinkingLevel,
@@ -15,12 +18,14 @@ import { readAdaptiveRoutingConfig } from "./config.js";
 import { inspectDelegatedSelection } from "./delegated-runtime.js";
 import { decideRoute } from "./engine.js";
 import { normalizeRouteCandidates } from "./normalize.js";
+import { deriveMirrorSets, resolveQuotaFailover } from "./quota-failover.js";
 import { readAdaptiveRoutingState, writeAdaptiveRoutingState } from "./state.js";
 import {
 	appendTelemetryEvent,
 	computeStats,
 	createDecisionId,
 	createFeedbackEvent,
+	createQuotaFailoverEvent,
 	formatStats,
 	hashPrompt,
 	readTelemetryEvents,
@@ -38,6 +43,10 @@ interface RuntimeState {
 	lastDecisionOverridden: boolean;
 	lastDecisionStartedAt?: number;
 	applyingRoute: boolean;
+	/** Last applied quota-failover switch, for status display. */
+	lastFailover?: { from: string; to: string; at: number };
+	/** Dedupe key for shadow-mode failover suggestions. */
+	failoverNoticeKey?: string;
 }
 
 export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
@@ -48,6 +57,8 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 		lastDecisionPromptHash: undefined,
 		lastDecisionStartedAt: undefined,
 		lastDecisionTurnCount: 0,
+		lastFailover: undefined,
+		failoverNoticeKey: undefined,
 		state: readAdaptiveRoutingState(),
 		usage: undefined,
 	};
@@ -70,10 +81,11 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 			return undefined;
 		}
 		const lockLabel = runtime.state.lock ? ` 🔒 ${runtime.state.lock.model}:${runtime.state.lock.thinking}` : "";
+		const failoverLabel = runtime.lastFailover ? ` ⟲ ${runtime.lastFailover.to}` : "";
 		const decision = runtime.lastDecision;
 		return decision
-			? `${mode} → ${decision.selectedModel}:${decision.selectedThinking}${lockLabel}`
-			: `${mode}${lockLabel}`;
+			? `${mode} → ${decision.selectedModel}:${decision.selectedThinking}${failoverLabel}${lockLabel}`
+			: `${mode}${failoverLabel}${lockLabel}`;
 	}
 
 	function updateStatus(ctx: ExtensionContext): void {
@@ -92,10 +104,7 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 		const providers: ProviderUsageState["providers"] = {};
 		if (providerPayload && typeof providerPayload === "object") {
 			for (const [provider, value] of Object.entries(providerPayload)) {
-				providers[provider] = {
-					confidence: extractQuotaConfidence(value),
-					remainingPct: extractRemainingPct(value),
-				};
+				providers[provider] = extractProviderQuota(value);
 			}
 		}
 		runtime.usage = {
@@ -151,6 +160,9 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 	});
 
 	pi.on("model_select", async (event, ctx) => {
+		if (!runtime.applyingRoute) {
+			runtime.lastFailover = undefined;
+		}
 		if (!runtime.applyingRoute && shouldRecordOverride(event, runtime.lastDecision)) {
 			appendTelemetryEvent(readAdaptiveRoutingConfig().telemetry, {
 				decisionId: runtime.lastDecision?.id,
@@ -276,17 +288,19 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 				});
 			}
 			ctx.ui.notify(`Adaptive route suggestion: ${decision.selectedModel} · ${decision.selectedThinking}`, "info");
+			await applyQuotaFailover(pi, ctx, currentModel ?? decision.selectedModel, candidates, mode, runtime);
 			updateStatus(ctx);
 			return;
 		}
 
 		await applyDecision(pi, ctx, decision, candidates, runtime);
+		await applyQuotaFailover(pi, ctx, decision.selectedModel, candidates, mode, runtime);
 		updateStatus(ctx);
 	});
 
 	const routeCommand = {
 		description:
-			"Adaptive routing controls: /route [status|on|off|shadow|auto|explain|assignments|delegated|why|lock|unlock|refresh|feedback|stats] and /route:<subcommand> aliases",
+			"Adaptive routing controls: /route [status|on|off|shadow|auto|explain|failover|assignments|delegated|why|lock|unlock|refresh|feedback|stats] and /route:<subcommand> aliases",
 		async handler(args: string, ctx: ExtensionCommandContext) {
 			const command = args.trim();
 			const [head, ...rest] = command.split(/\s+/).filter(Boolean);
@@ -377,6 +391,10 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 					await openOverlay(ctx, buildDelegatedWhyLines(readAdaptiveRoutingConfig(), ctx, rest));
 					return;
 				}
+				case "failover": {
+					await openOverlay(ctx, buildQuotaFailoverLines(readAdaptiveRoutingConfig(), ctx, runtime));
+					return;
+				}
 				case "explain": {
 					await openOverlay(ctx, buildExplanationLines(runtime.lastDecision, runtime.usage));
 					return;
@@ -424,6 +442,11 @@ export default function adaptiveRoutingExtension(pi: ExtensionAPI) {
 			description: "Explain the latest adaptive route decision.",
 			name: "route explain",
 			subcommand: "explain",
+		},
+		{
+			description: "Show quota failover mirror sets and the current failover decision.",
+			name: "route failover",
+			subcommand: "failover",
 		},
 		{
 			description: "Show delegated routing assignments.",
@@ -513,6 +536,77 @@ async function applyDecision(
 	}
 }
 
+function formatPctLeft(pct: number | undefined): string {
+	return typeof pct === "number" ? `${Math.round(pct * 10) / 10}% left` : "quota unknown";
+}
+
+function describeFailoverSwitch(action: Extract<QuotaFailoverAction, { type: "switch" }>): string {
+	const fromWindow = action.windowLabel ? ` ${action.windowLabel}` : "";
+	if (action.reason === "return-home") {
+		return `${action.from} recovered (${formatPctLeft(action.toRemainingPct)}) → returning to ${action.to}`;
+	}
+	return `${action.from}${fromWindow} at ${formatPctLeft(action.fromRemainingPct)} → ${action.to} (${formatPctLeft(action.toRemainingPct)})`;
+}
+
+async function applyQuotaFailover(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext,
+	effectiveFullId: string,
+	candidates: NormalizedRouteCandidate[],
+	mode: AdaptiveRoutingMode,
+	runtime: RuntimeState,
+): Promise<void> {
+	const config = readAdaptiveRoutingConfig();
+	const failoverConfig = config.quotaFailover;
+	if (!failoverConfig.enabled || !runtime.usage) {
+		return;
+	}
+
+	const action = resolveQuotaFailover({
+		config: failoverConfig,
+		currentFullId: effectiveFullId,
+		locked: Boolean(runtime.state.lock),
+		now: Date.now(),
+		quota: runtime.usage.providers,
+		sets: deriveMirrorSets(candidates, failoverConfig),
+	});
+
+	if (action.type === "keep") {
+		if (action.reason === "healthy" || action.reason === "no-set") {
+			runtime.failoverNoticeKey = undefined;
+			runtime.lastFailover = undefined;
+		}
+		return;
+	}
+
+	const noticeKey = `${action.from}->${action.to}:${action.reason}`;
+	if (mode === "shadow") {
+		if (runtime.failoverNoticeKey !== noticeKey) {
+			runtime.failoverNoticeKey = noticeKey;
+			ctx.ui.notify(`Quota failover suggestion: ${describeFailoverSwitch(action)}`, "info");
+			appendTelemetryEvent(config.telemetry, createQuotaFailoverEvent(action, false));
+		}
+		return;
+	}
+
+	const target = candidates.find((candidate) => candidate.fullId === action.to);
+
+	runtime.applyingRoute = true;
+	try {
+		const ok = target ? await pi.setModel(target.model) : false;
+		if (!ok) {
+			ctx.ui.notify(`Failed to switch to ${action.to}.`, "error");
+			return;
+		}
+		runtime.lastFailover = { at: Date.now(), from: action.from, to: action.to };
+		runtime.failoverNoticeKey = undefined;
+		ctx.ui.notify(`Quota failover: ${describeFailoverSwitch(action)}`, "info");
+		appendTelemetryEvent(config.telemetry, createQuotaFailoverEvent(action, true));
+	} finally {
+		runtime.applyingRoute = false;
+	}
+}
+
 function shouldRecordOverride(
 	event: { model?: { provider: string; id: string } },
 	lastDecision: RouteDecision | undefined,
@@ -523,37 +617,46 @@ function shouldRecordOverride(
 	return `${event.model.provider}/${event.model.id}` !== lastDecision.selectedModel;
 }
 
-function extractQuotaConfidence(value: unknown): ProviderUsageState["providers"][string]["confidence"] {
+/**
+ * Summarize one provider's `usage:limits` entry.
+ *
+ * Reads the usage-tracker's `ProviderRateLimits` shape: `windows[].percentLeft`
+ * plus `probedAt`. `remainingPct` is the most-constrained window, with its label.
+ */
+function extractProviderQuota(value: unknown): ProviderUsageState["providers"][string] {
 	if (!value || typeof value !== "object") {
-		return "unknown";
+		return { confidence: "unknown" };
 	}
-	const typedValue = value as { windows?: unknown[]; stale?: boolean };
-	if (Array.isArray(typedValue.windows) && typedValue.windows.length > 0) {
-		return "authoritative";
+	const typed = value as { windows?: unknown[]; stale?: unknown; probedAt?: unknown };
+	if (!Array.isArray(typed.windows) || typed.windows.length === 0) {
+		return { confidence: typed.stale ? "estimated" : "unknown" };
 	}
-	if (typedValue.stale) {
-		return "estimated";
-	}
-	return "unknown";
-}
 
-function extractRemainingPct(value: unknown): number | undefined {
-	if (!value || typeof value !== "object") {
-		return undefined;
+	let minPct = Number.POSITIVE_INFINITY;
+	let windowLabel: string | undefined;
+	for (const window of typed.windows) {
+		if (!window || typeof window !== "object") {
+			continue;
+		}
+		const entry = window as { percentLeft?: unknown; label?: unknown };
+		const pct = typeof entry.percentLeft === "number" ? entry.percentLeft : Number(entry.percentLeft);
+		if (!Number.isFinite(pct)) {
+			continue;
+		}
+		if (pct < minPct) {
+			minPct = pct;
+			windowLabel = typeof entry.label === "string" ? entry.label : windowLabel;
+		}
 	}
-	const typedValue = value as { windows?: unknown[] };
-	if (!Array.isArray(typedValue.windows)) {
-		return undefined;
+	if (!Number.isFinite(minPct)) {
+		return { confidence: "unknown" };
 	}
-	const percentages = typedValue.windows
-		.map((window: unknown) =>
-			window && typeof window === "object" ? Number((window as { remainingPct?: unknown }).remainingPct) : Number.NaN,
-		)
-		.filter((pct: number) => Number.isFinite(pct));
-	if (percentages.length === 0) {
-		return undefined;
-	}
-	return Math.min(...percentages);
+	return {
+		confidence: "authoritative",
+		probedAt: typeof typed.probedAt === "number" ? typed.probedAt : undefined,
+		remainingPct: minPct,
+		windowLabel,
+	};
 }
 
 function normalizeFeedbackCategory(value: string | undefined): RouteFeedbackCategory | undefined {
@@ -571,6 +674,66 @@ function normalizeFeedbackCategory(value: string | undefined): RouteFeedbackCate
 			return undefined;
 		}
 	}
+}
+
+function buildQuotaFailoverLines(
+	config: ReturnType<typeof readAdaptiveRoutingConfig>,
+	ctx: ExtensionCommandContext,
+	runtime: RuntimeState,
+): string[] {
+	const failover = config.quotaFailover;
+	const lines: string[] = [];
+	if (!failover.enabled) {
+		lines.push("Quota failover: disabled (set quotaFailover.enabled=true in config.json)");
+		return lines;
+	}
+
+	lines.push(
+		`Quota failover: switch ≤${failover.switchBelowPct}% · mirror ≥${failover.requireMirrorAbovePct}% · returnHome ${failover.returnHome ? "on" : "off"} · unknown ${failover.onUnknownQuota} · stale ≤${failover.staleAfterMinutes}m${failover.autoMirror ? " · autoMirror on" : ""}`,
+	);
+
+	const currentFullId = ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined;
+	const candidates = normalizeRouteCandidates(ctx.modelRegistry.getAvailable());
+	const sets = deriveMirrorSets(candidates, failover);
+	if (sets.length === 0) {
+		lines.push("No mirror sets resolved from the available models.");
+		return lines;
+	}
+
+	const providers = runtime.usage?.providers ?? {};
+	for (const [index, set] of sets.entries()) {
+		const origin = set.explicit ? "config" : "auto";
+		const home = set.home ? ` · home ${set.home}` : "";
+		lines.push(``);
+		lines.push(`Set ${index + 1} (${origin}${home}):`);
+		for (const member of set.members) {
+			const provider = member.slice(0, member.indexOf("/")) || member;
+			const quota = providers[provider];
+			const pct =
+				typeof quota?.remainingPct === "number" ? `${Math.round(quota.remainingPct * 10) / 10}% left` : "quota unknown";
+			const window = quota?.windowLabel ? ` · ${quota.windowLabel}` : "";
+			const active = currentFullId === member ? " ← active" : "";
+			lines.push(`  • ${member} — ${pct}${window}${active}`);
+		}
+	}
+
+	if (currentFullId) {
+		const action = resolveQuotaFailover({
+			config: failover,
+			currentFullId,
+			locked: Boolean(runtime.state.lock),
+			now: Date.now(),
+			quota: providers,
+			sets,
+		});
+		const summary =
+			action.type === "switch"
+				? `switch → ${action.to} (${action.reason})`
+				: `keep (${action.reason}${action.reason === "locked" ? " — /route lock pins the model" : ""})`;
+		lines.push(``);
+		lines.push(`Decision now: ${summary}`);
+	}
+	return lines;
 }
 
 function buildStatusLine(

--- a/packages/monopi__adaptive-routing/quota-failover.test.ts
+++ b/packages/monopi__adaptive-routing/quota-failover.test.ts
@@ -1,0 +1,355 @@
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedRouteCandidate, ProviderUsageState, QuotaFailoverConfig } from "./types.js";
+
+import { normalizeAdaptiveRoutingConfig } from "./config.js";
+import { DEFAULT_QUOTA_FAILOVER_CONFIG } from "./defaults.js";
+import { deriveMirrorSets, normalizeMirrorModelId, resolveQuotaFailover, type MirrorSet } from "./quota-failover.js";
+
+function candidate(provider: string, id: string): NormalizedRouteCandidate {
+	return {
+		authenticated: true,
+		available: true,
+		contextWindow: 200_000,
+		costKnown: true,
+		fallbackGroups: [],
+		family: undefined,
+		fullId: `${provider}/${id}`,
+		input: ["text"],
+		label: `${provider}/${id}`,
+		maxThinkingLevel: "high",
+		maxTokens: 32_768,
+		model: { id, provider } as NormalizedRouteCandidate["model"],
+		modelId: id,
+		provider,
+		reasoning: true,
+		tags: [],
+		tier: "cheap",
+	};
+}
+
+const GLM_CANDIDATES = [
+	candidate("ollama-cloud", "glm-5.3-flash"),
+	candidate("zai", "glm-5.3-flash"),
+	candidate("opencode-go", "glm-5.3-flash"),
+];
+
+const GLM_SET: MirrorSet = {
+	explicit: true,
+	home: "ollama-cloud/glm-5.3-flash",
+	members: ["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash", "opencode-go/glm-5.3-flash"],
+};
+
+function quota(
+	entries: Record<string, { remainingPct?: number; probedAt?: number; windowLabel?: string }>,
+): ProviderUsageState["providers"] {
+	const providers: ProviderUsageState["providers"] = {};
+	for (const [provider, value] of Object.entries(entries)) {
+		providers[provider] = { confidence: value.remainingPct === undefined ? "unknown" : "authoritative", ...value };
+	}
+	return providers;
+}
+
+function resolve(
+	overrides: Partial<Parameters<typeof resolveQuotaFailover>[0]> = {},
+	currentFullId = "ollama-cloud/glm-5.3-flash",
+	providers: ProviderUsageState["providers"] = quota({
+		"ollama-cloud": { probedAt: Date.now(), remainingPct: 0.4, windowLabel: "Session (5h)" },
+		"opencode-go": { probedAt: Date.now(), remainingPct: 88 },
+		zai: { probedAt: Date.now(), remainingPct: 97.1 },
+	}),
+) {
+	return resolveQuotaFailover({
+		config: DEFAULT_QUOTA_FAILOVER_CONFIG,
+		currentFullId,
+		now: Date.now(),
+		quota: providers,
+		sets: [GLM_SET],
+		...overrides,
+	});
+}
+
+describe("normalizeMirrorModelId", () => {
+	it("strips provider tags and normalizes case", () => {
+		expect(normalizeMirrorModelId("Glm-5.3-Flash:cloud")).toBe("glm-5.3-flash");
+		expect(normalizeMirrorModelId("glm-5.3-flash")).toBe("glm-5.3-flash");
+	});
+});
+
+describe("deriveMirrorSets", () => {
+	it("resolves explicit config sets against available candidates", () => {
+		const config: QuotaFailoverConfig = {
+			...DEFAULT_QUOTA_FAILOVER_CONFIG,
+			autoMirror: false,
+			mirrorSets: [
+				["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash", "opencode-go/glm-5.3-flash", "groq/not-available"],
+			],
+		};
+		const sets = deriveMirrorSets(GLM_CANDIDATES, config);
+		expect(sets).toHaveLength(1);
+		expect(sets[0]).toEqual({
+			explicit: true,
+			home: "ollama-cloud/glm-5.3-flash",
+			members: ["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash", "opencode-go/glm-5.3-flash"],
+		});
+	});
+
+	it("drops explicit sets with fewer than two available members", () => {
+		const config: QuotaFailoverConfig = {
+			...DEFAULT_QUOTA_FAILOVER_CONFIG,
+			autoMirror: false,
+			mirrorSets: [["ollama-cloud/glm-5.3-flash", "groq/gone"]],
+		};
+		expect(deriveMirrorSets(GLM_CANDIDATES, config)).toHaveLength(0);
+	});
+
+	it("dedupes identical explicit sets", () => {
+		const config: QuotaFailoverConfig = {
+			...DEFAULT_QUOTA_FAILOVER_CONFIG,
+			autoMirror: false,
+			mirrorSets: [
+				["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash"],
+				["zai/glm-5.3-flash", "ollama-cloud/glm-5.3-flash"],
+			],
+		};
+		expect(deriveMirrorSets(GLM_CANDIDATES, config)).toHaveLength(1);
+	});
+
+	it("auto-derives sets from identical model ids across providers", () => {
+		const config = { ...DEFAULT_QUOTA_FAILOVER_CONFIG, autoMirror: true };
+		const sets = deriveMirrorSets(GLM_CANDIDATES, config);
+		expect(sets).toHaveLength(1);
+		expect(sets[0]?.explicit).toBe(false);
+		expect(sets[0]?.home).toBeUndefined();
+		expect(sets[0]?.members).toHaveLength(3);
+	});
+
+	it("skips auto groups confined to one provider and dedupes against explicit sets", () => {
+		const candidates = [
+			...GLM_CANDIDATES,
+			candidate("ollama-cloud", "qwen3-coder:397b"),
+			candidate("zai", "other-model"),
+		];
+		const config: QuotaFailoverConfig = {
+			...DEFAULT_QUOTA_FAILOVER_CONFIG,
+			autoMirror: true,
+			mirrorSets: [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash", "opencode-go/glm-5.3-flash"]],
+		};
+		const sets = deriveMirrorSets(candidates, config);
+		// Explicit glm set + no auto duplicates; the unrelated same-provider pairs add nothing.
+		expect(sets).toHaveLength(1);
+		expect(sets[0]?.explicit).toBe(true);
+	});
+
+	it("matches tagged ollama ids to untagged set members", () => {
+		const candidates = [candidate("ollama-cloud", "glm-5.3-flash:cloud"), candidate("zai", "glm-5.3-flash")];
+		const config: QuotaFailoverConfig = {
+			...DEFAULT_QUOTA_FAILOVER_CONFIG,
+			autoMirror: true,
+			mirrorSets: [],
+		};
+		const sets = deriveMirrorSets(candidates, config);
+		expect(sets).toHaveLength(1);
+		expect(sets[0]?.members).toContain("ollama-cloud/glm-5.3-flash:cloud");
+	});
+});
+
+describe("resolveQuotaFailover", () => {
+	it("keeps models outside any mirror set", () => {
+		const action = resolve({}, "anthropic/claude-sonnet-4");
+		expect(action).toEqual({ reason: "no-set", type: "keep" });
+	});
+
+	it("keeps the current model while quota is healthy", () => {
+		const action = resolve(
+			{},
+			"ollama-cloud/glm-5.3-flash",
+			quota({ "ollama-cloud": { probedAt: Date.now(), remainingPct: 42 } }),
+		);
+		expect(action).toEqual({ reason: "healthy", type: "keep" });
+	});
+
+	it("switches to the healthiest mirror when the active provider is exhausted", () => {
+		const action = resolve();
+		expect(action).toMatchObject({
+			from: "ollama-cloud/glm-5.3-flash",
+			fromRemainingPct: 0.4,
+			reason: "exhausted",
+			to: "zai/glm-5.3-flash",
+			toRemainingPct: 97.1,
+			type: "switch",
+			windowLabel: "Session (5h)",
+		});
+	});
+
+	it("prefers earlier set order when mirrors tie on remaining quota", () => {
+		const action = resolve(
+			{},
+			"ollama-cloud/glm-5.3-flash",
+			quota({
+				"ollama-cloud": { probedAt: Date.now(), remainingPct: 0.2 },
+				"opencode-go": { probedAt: Date.now(), remainingPct: 50 },
+				zai: { probedAt: Date.now(), remainingPct: 50 },
+			}),
+		);
+		expect(action).toMatchObject({ to: "zai/glm-5.3-flash", type: "switch" });
+	});
+
+	it("skips mirrors below the required threshold", () => {
+		const action = resolve(
+			{ config: { ...DEFAULT_QUOTA_FAILOVER_CONFIG, requireMirrorAbovePct: 60 } },
+			"ollama-cloud/glm-5.3-flash",
+			quota({
+				"ollama-cloud": { probedAt: Date.now(), remainingPct: 0.2 },
+				"opencode-go": { probedAt: Date.now(), remainingPct: 50 },
+				zai: { probedAt: Date.now(), remainingPct: 55 },
+			}),
+		);
+		expect(action).toEqual({ reason: "no-mirror", type: "keep" });
+	});
+
+	it("keeps the current model when quota is unknown and the policy is stay", () => {
+		const action = resolve(
+			{},
+			"ollama-cloud/glm-5.3-flash",
+			quota({ "ollama-cloud": {}, zai: { probedAt: Date.now(), remainingPct: 90 } }),
+		);
+		expect(action).toEqual({ reason: "quota-unknown", type: "keep" });
+	});
+
+	it("treats unknown quota as exhausted when the policy is switch", () => {
+		const action = resolve(
+			{ config: { ...DEFAULT_QUOTA_FAILOVER_CONFIG, onUnknownQuota: "switch" } },
+			"ollama-cloud/glm-5.3-flash",
+			quota({ "ollama-cloud": {}, zai: { probedAt: Date.now(), remainingPct: 90 } }),
+		);
+		expect(action).toMatchObject({ reason: "exhausted", to: "zai/glm-5.3-flash", type: "switch" });
+	});
+
+	it("treats stale snapshots as unknown", () => {
+		const stale = Date.now() - (DEFAULT_QUOTA_FAILOVER_CONFIG.staleAfterMinutes + 1) * 60_000;
+		const action = resolve(
+			{},
+			"ollama-cloud/glm-5.3-flash",
+			quota({
+				"ollama-cloud": { probedAt: stale, remainingPct: 0.1 },
+				zai: { probedAt: Date.now(), remainingPct: 90 },
+			}),
+		);
+		expect(action).toEqual({ reason: "quota-unknown", type: "keep" });
+	});
+
+	it("trusts snapshots without a probe timestamp", () => {
+		const action = resolve(
+			{},
+			"ollama-cloud/glm-5.3-flash",
+			quota({ "ollama-cloud": { remainingPct: 0.1 }, zai: { remainingPct: 90 } }),
+		);
+		expect(action).toMatchObject({ reason: "exhausted", to: "zai/glm-5.3-flash", type: "switch" });
+	});
+
+	it("returns home once the home provider recovers", () => {
+		const action = resolve(
+			{},
+			"zai/glm-5.3-flash",
+			quota({
+				"ollama-cloud": { probedAt: Date.now(), remainingPct: 80, windowLabel: "Session (5h)" },
+				zai: { probedAt: Date.now(), remainingPct: 40 },
+			}),
+		);
+		expect(action).toMatchObject({
+			from: "zai/glm-5.3-flash",
+			reason: "return-home",
+			to: "ollama-cloud/glm-5.3-flash",
+			toRemainingPct: 80,
+			type: "switch",
+		});
+	});
+
+	it("stays away from home while it is still exhausted", () => {
+		const action = resolve(
+			{},
+			"zai/glm-5.3-flash",
+			quota({
+				"ollama-cloud": { probedAt: Date.now(), remainingPct: 1 },
+				"opencode-go": { probedAt: Date.now(), remainingPct: 30 },
+				zai: { probedAt: Date.now(), remainingPct: 40 },
+			}),
+		);
+		expect(action).toEqual({ reason: "healthy", type: "keep" });
+	});
+
+	it("never switches while a manual lock is active", () => {
+		const action = resolve({ locked: true });
+		expect(action).toEqual({ reason: "locked", type: "keep" });
+	});
+
+	it("never switches to a mirror on the same provider as the current model", () => {
+		const action = resolve(
+			{
+				sets: [{ explicit: true, home: "zai/glm-5.3-flash", members: ["zai/glm-5.3-flash", "zai/glm-5.3-flash:pro"] }],
+			},
+			"zai/glm-5.3-flash",
+			quota({ zai: { probedAt: Date.now(), remainingPct: 0.1 } }),
+		);
+		expect(action).toEqual({ reason: "no-mirror", type: "keep" });
+	});
+
+	it("ignores members without a provider prefix when matching", () => {
+		const action = resolve(
+			{
+				sets: [{ explicit: true, members: ["ollama-cloud/glm-5.3-flash", "glm-5.3-flash"] }],
+			},
+			"ollama-cloud/glm-5.3-flash",
+			quota({ "ollama-cloud": { probedAt: Date.now(), remainingPct: 0.1 } }),
+		);
+		expect(action).toEqual({ reason: "no-mirror", type: "keep" });
+	});
+});
+
+describe("quotaFailover config normalization", () => {
+	it("fills defaults for a missing section", () => {
+		const config = normalizeAdaptiveRoutingConfig({});
+		expect(config.quotaFailover).toEqual(DEFAULT_QUOTA_FAILOVER_CONFIG);
+		expect(config.quotaFailover.enabled).toBe(false);
+	});
+
+	it("falls back when the section is not an object", () => {
+		const config = normalizeAdaptiveRoutingConfig({ quotaFailover: "nope" });
+		expect(config.quotaFailover).toEqual(DEFAULT_QUOTA_FAILOVER_CONFIG);
+	});
+
+	it("normalizes thresholds, sets, and flags", () => {
+		const config = normalizeAdaptiveRoutingConfig({
+			quotaFailover: {
+				autoMirror: false,
+				enabled: true,
+				mirrorSets: [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash"]],
+				onUnknownQuota: "switch",
+				requireMirrorAbovePct: "30",
+				staleAfterMinutes: 5,
+				switchBelowPct: "not-a-number",
+			},
+		});
+		expect(config.quotaFailover).toEqual({
+			autoMirror: false,
+			enabled: true,
+			mirrorSets: [["ollama-cloud/glm-5.3-flash", "zai/glm-5.3-flash"]],
+			onUnknownQuota: "switch",
+			requireMirrorAbovePct: 30,
+			returnHome: true,
+			staleAfterMinutes: 5,
+			switchBelowPct: 5,
+		});
+	});
+
+	it("drops mirror sets with fewer than two valid ids", () => {
+		const config = normalizeAdaptiveRoutingConfig({
+			quotaFailover: {
+				enabled: true,
+				mirrorSets: [["only-one"], "nope", ["a", "b"]],
+			},
+		});
+		expect(config.quotaFailover.mirrorSets).toEqual([["a", "b"]]);
+	});
+});

--- a/packages/monopi__adaptive-routing/quota-failover.ts
+++ b/packages/monopi__adaptive-routing/quota-failover.ts
@@ -1,0 +1,214 @@
+import type {
+	NormalizedRouteCandidate,
+	ProviderUsageState,
+	QuotaFailoverAction,
+	QuotaFailoverConfig,
+} from "./types.js";
+
+export type { QuotaFailoverAction } from "./types.js";
+
+/** A resolved mirror set: ordered members plus the preferred home (explicit sets only). */
+export interface MirrorSet {
+	/** Full model ids in preference order. First entry of an explicit set is home. */
+	members: string[];
+	/** Preferred model to return to once quota recovers; undefined for auto-derived sets. */
+	home?: string;
+	/** True when the set came from config `mirrorSets` rather than auto-derivation. */
+	explicit: boolean;
+}
+
+export type QuotaFailoverKeepAction = Extract<QuotaFailoverAction, { type: "keep" }>;
+
+export interface QuotaFailoverInput {
+	currentFullId: string;
+	sets: MirrorSet[];
+	quota: ProviderUsageState["providers"];
+	config: QuotaFailoverConfig;
+	now: number;
+	/** When true (manual `/route lock`), failover never switches. */
+	locked?: boolean;
+}
+
+/** Normalize a bare model id so mirrors match across providers (`Glm-5.3-Flash:cloud` → `glm-5.3-flash`). */
+export function normalizeMirrorModelId(modelId: string): string {
+	return modelId
+		.trim()
+		.toLowerCase()
+		.replace(/:[^:]+$/, "");
+}
+
+function providerOf(fullId: string): string {
+	const separator = fullId.indexOf("/");
+	return separator === -1 ? fullId : fullId.slice(0, separator);
+}
+
+function fullIdMatches(candidateFullId: string, fullId: string): boolean {
+	if (candidateFullId === fullId) {
+		return true;
+	}
+	const candidateSeparator = candidateFullId.indexOf("/");
+	const separator = fullId.indexOf("/");
+	if (candidateSeparator === -1 || separator === -1) {
+		return false;
+	}
+	return (
+		candidateFullId.slice(0, candidateSeparator) === fullId.slice(0, separator) &&
+		normalizeMirrorModelId(candidateFullId.slice(candidateSeparator + 1)) ===
+			normalizeMirrorModelId(fullId.slice(separator + 1))
+	);
+}
+
+interface UsableQuota {
+	remainingPct: number;
+	windowLabel?: string;
+}
+
+function usableQuota(
+	entry: ProviderUsageState["providers"][string] | undefined,
+	config: QuotaFailoverConfig,
+	now: number,
+): UsableQuota | null {
+	if (!entry || typeof entry.remainingPct !== "number" || !Number.isFinite(entry.remainingPct)) {
+		return null;
+	}
+	const probedAt = typeof entry.probedAt === "number" ? entry.probedAt : undefined;
+	if (probedAt !== undefined && now - probedAt > config.staleAfterMinutes * 60_000) {
+		return null;
+	}
+	// Snapshots without a timestamp come from a fresh in-process broadcast; trust them.
+	return { remainingPct: entry.remainingPct, windowLabel: entry.windowLabel };
+}
+
+/** Build the mirror sets that apply to the available candidates: explicit config sets first, then auto-derived. */
+export function deriveMirrorSets(candidates: NormalizedRouteCandidate[], config: QuotaFailoverConfig): MirrorSet[] {
+	const available = new Set(candidates.map((candidate) => candidate.fullId));
+	const providerByFullId = new Map(candidates.map((candidate) => [candidate.fullId, candidate.provider]));
+
+	const sets: MirrorSet[] = [];
+	const seenSets = new Set<string>();
+
+	for (const raw of config.mirrorSets) {
+		const members = raw.filter((fullId) => available.has(fullId));
+		if (members.length < 2) {
+			continue;
+		}
+		const key = [...members].sort().join("|");
+		if (seenSets.has(key)) {
+			continue;
+		}
+		seenSets.add(key);
+		sets.push({ explicit: true, home: members[0], members });
+	}
+
+	if (config.autoMirror) {
+		// Group available models by normalized bare id; groups spanning 2+ providers mirror each other.
+		const groups = new Map<string, string[]>();
+		for (const candidate of candidates) {
+			const normalized = normalizeMirrorModelId(candidate.modelId);
+			const bucket = groups.get(normalized);
+			if (bucket) {
+				bucket.push(candidate.fullId);
+			} else {
+				groups.set(normalized, [candidate.fullId]);
+			}
+		}
+		for (const members of groups.values()) {
+			const distinctProviders = new Set(members.map((fullId) => providerByFullId.get(fullId)));
+			if (members.length < 2 || distinctProviders.size < 2) {
+				continue;
+			}
+			const key = [...members].sort().join("|");
+			if (seenSets.has(key)) {
+				continue;
+			}
+			seenSets.add(key);
+			// Order by the candidate list (registry) order; no intrinsic home.
+			sets.push({ explicit: false, members });
+		}
+	}
+
+	return sets;
+}
+
+/**
+ * Resolve whether the current model should stay or switch to a mirror.
+ *
+ * Rules (in order):
+ * 1. No mirror set contains the current model → keep.
+ * 2. A manual lock pins the model → keep.
+ * 3. Active provider quota unknown/stale → keep (`onUnknownQuota: "stay"`), or treat as exhausted.
+ * 4. Active provider above the switch threshold → keep (or return home when it has recovered).
+ * 5. Active provider at/below the threshold → first mirror (by remaining % desc, then set order)
+ *    on a different provider with quota ≥ `requireMirrorAbovePct`; otherwise keep.
+ */
+export function resolveQuotaFailover(input: QuotaFailoverInput): QuotaFailoverAction {
+	if (input.locked) {
+		return { type: "keep", reason: "locked" };
+	}
+
+	const set = input.sets.find((members) =>
+		members.members.some((fullId) => fullIdMatches(fullId, input.currentFullId)),
+	);
+	if (!set) {
+		return { type: "keep", reason: "no-set" };
+	}
+
+	const activeProvider = providerOf(input.currentFullId);
+	const activeQuota = usableQuota(input.quota[activeProvider], input.config, input.now);
+
+	if (!activeQuota) {
+		if (input.config.onUnknownQuota !== "switch") {
+			return { type: "keep", reason: "quota-unknown" };
+		}
+		// Fall through: treat unknown active quota as exhausted.
+	}
+
+	if (activeQuota && activeQuota.remainingPct > input.config.switchBelowPct) {
+		if (input.config.returnHome && set.home && !fullIdMatches(set.home, input.currentFullId)) {
+			const homeQuota = usableQuota(input.quota[providerOf(set.home)], input.config, input.now);
+			if (homeQuota && homeQuota.remainingPct >= input.config.requireMirrorAbovePct) {
+				return {
+					from: input.currentFullId,
+					fromRemainingPct: activeQuota.remainingPct,
+					reason: "return-home",
+					to: set.home,
+					toRemainingPct: homeQuota.remainingPct,
+					type: "switch",
+					windowLabel: homeQuota.windowLabel,
+				};
+			}
+		}
+		return { type: "keep", reason: "healthy" };
+	}
+
+	const activeRemaining = activeQuota?.remainingPct;
+	let best: { fullId: string; provider: string; quota: UsableQuota; order: number } | undefined;
+	for (let index = 0; index < set.members.length; index++) {
+		const fullId = set.members[index];
+		const provider = providerOf(fullId);
+		if (provider === activeProvider || fullIdMatches(fullId, input.currentFullId)) {
+			continue;
+		}
+		const quota = usableQuota(input.quota[provider], input.config, input.now);
+		if (!quota || quota.remainingPct < input.config.requireMirrorAbovePct) {
+			continue;
+		}
+		if (!best || quota.remainingPct > best.quota.remainingPct) {
+			best = { fullId, order: index, provider, quota };
+		}
+	}
+
+	if (!best) {
+		return { type: "keep", reason: "no-mirror" };
+	}
+
+	return {
+		from: input.currentFullId,
+		fromRemainingPct: activeRemaining,
+		reason: "exhausted",
+		to: best.fullId,
+		toRemainingPct: best.quota.remainingPct,
+		type: "switch",
+		windowLabel: activeQuota?.windowLabel,
+	};
+}

--- a/packages/monopi__adaptive-routing/telemetry.ts
+++ b/packages/monopi__adaptive-routing/telemetry.ts
@@ -7,6 +7,7 @@ import type {
 	AdaptiveRoutingStats,
 	AdaptiveRoutingTelemetryConfig,
 	AdaptiveRoutingTelemetryEvent,
+	QuotaFailoverAction,
 	RouteDecision,
 	RouteFeedbackCategory,
 } from "./types.js";
@@ -223,6 +224,25 @@ export function createFeedbackEvent(
 		sessionId,
 		timestamp: Date.now(),
 		type: "route_feedback",
+	};
+}
+
+export function createQuotaFailoverEvent(
+	action: Extract<QuotaFailoverAction, { type: "switch" }>,
+	applied: boolean,
+	sessionId?: string,
+): AdaptiveRoutingTelemetryEvent {
+	return {
+		applied,
+		from: action.from,
+		fromRemainingPct: action.fromRemainingPct,
+		reason: action.reason,
+		sessionId,
+		timestamp: Date.now(),
+		to: action.to,
+		toRemainingPct: action.toRemainingPct,
+		type: "route_quota_failover",
+		windowLabel: action.windowLabel,
 	};
 }
 

--- a/packages/monopi__adaptive-routing/types.ts
+++ b/packages/monopi__adaptive-routing/types.ts
@@ -5,6 +5,23 @@ export type AdaptiveRoutingTelemetryMode = "off" | "local" | "export";
 export type AdaptiveRoutingPrivacyLevel = "minimal" | "redacted" | "full-local";
 export type QuotaConfidence = "authoritative" | "estimated" | "unknown";
 
+export type QuotaFailoverUnknownPolicy = "stay" | "switch";
+
+export type QuotaFailoverAction =
+	| {
+			type: "keep";
+			reason: "no-set" | "quota-unknown" | "healthy" | "no-mirror" | "locked";
+	  }
+	| {
+			type: "switch";
+			reason: "exhausted" | "return-home";
+			from: string;
+			to: string;
+			fromRemainingPct?: number;
+			toRemainingPct?: number;
+			windowLabel?: string;
+	  };
+
 export type RouteIntent =
 	| "quick-qna"
 	| "planning"
@@ -114,6 +131,31 @@ export interface DelegatedModelSelectionConfig {
 	roleOverrides: Record<string, DelegatedSelectionOverride>;
 }
 
+/**
+ * Same-model-different-provider failover.
+ *
+ * When the active model belongs to a mirror set and its provider's most
+ * constrained quota window drops to `switchBelowPct`, switch to a mirror on a
+ * provider that still has at least `requireMirrorAbovePct` remaining.
+ */
+export interface QuotaFailoverConfig {
+	enabled: boolean;
+	/** Ordered mirror sets of full model ids (`provider/model`). First entry is home. */
+	mirrorSets: string[][];
+	/** Derive extra mirror sets from identical model ids across providers. */
+	autoMirror: boolean;
+	/** Switch away when the active provider's most-constrained window is at or below this. */
+	switchBelowPct: number;
+	/** A mirror only qualifies when its provider has at least this remaining. */
+	requireMirrorAbovePct: number;
+	/** Switch back to the set home once it recovers above `requireMirrorAbovePct`. */
+	returnHome: boolean;
+	/** "stay" keeps the current model when quota data is missing or stale. */
+	onUnknownQuota: QuotaFailoverUnknownPolicy;
+	/** Quota snapshots older than this count as unknown. */
+	staleAfterMinutes: number;
+}
+
 export interface AdaptiveRoutingConfig {
 	mode: AdaptiveRoutingMode;
 	routerModels: string[];
@@ -124,6 +166,7 @@ export interface AdaptiveRoutingConfig {
 	taskClasses: Record<string, TaskClassPolicy>;
 	providerReserves: Partial<Record<string, ProviderReservePolicy>>;
 	fallbackGroups: Record<string, FallbackGroupPolicy>;
+	quotaFailover: QuotaFailoverConfig;
 	delegatedRouting: DelegatedRoutingConfig;
 	delegatedModelSelection: DelegatedModelSelectionConfig;
 }
@@ -192,6 +235,10 @@ export interface ProviderUsageState {
 		{
 			confidence: QuotaConfidence;
 			remainingPct?: number;
+			/** Epoch ms of the last successful probe; used for staleness checks. */
+			probedAt?: number;
+			/** Label of the most-constrained window (e.g. "Session (5h)"). */
+			windowLabel?: string;
 		}
 	>;
 	sessionCost?: number;
@@ -296,12 +343,25 @@ export interface RouteShadowDisagreementTelemetryEvent extends TelemetryEventBas
 	};
 }
 
+export interface RouteQuotaFailoverTelemetryEvent extends TelemetryEventBase {
+	type: "route_quota_failover";
+	from: string;
+	to: string;
+	fromRemainingPct?: number;
+	toRemainingPct?: number;
+	windowLabel?: string;
+	reason: "exhausted" | "return-home";
+	/** False when the switch was suggested in shadow mode but not applied. */
+	applied: boolean;
+}
+
 export type AdaptiveRoutingTelemetryEvent =
 	| RouteDecisionTelemetryEvent
 	| RouteOverrideTelemetryEvent
 	| RouteFeedbackTelemetryEvent
 	| RouteOutcomeTelemetryEvent
-	| RouteShadowDisagreementTelemetryEvent;
+	| RouteShadowDisagreementTelemetryEvent
+	| RouteQuotaFailoverTelemetryEvent;
 
 export interface AdaptiveRoutingStats {
 	decisions: number;


### PR DESCRIPTION
## Summary

Implements the quota-failover API proposed and approved in discussion: when the active model belongs to a mirror set and its provider's most-constrained quota window drops to `switchBelowPct`, switch to the same model on a provider that still has quota — and return home once it recovers.

- **`quotaFailover` config** in `~/.pi/agent/extensions/adaptive-routing/config.json`: ordered `mirrorSets` (first entry is home), `autoMirror` derivation from identical model ids across providers, `switchBelowPct` / `requireMirrorAbovePct` thresholds, `returnHome`, `onUnknownQuota: stay`, and `staleAfterMinutes` staleness guard.
- **Decision resolver** (pure, fully unit-tested): keeps on no-set/unknown/healthy, switches to the healthiest qualifying mirror (remaining % desc, set order tiebreak), returns home on recovery, never switches under manual `/route lock`, and never considers same-provider members.
- **Runtime wiring**: applies at `before_agent_start` after the normal route decision — `pi.setModel()` in `auto`, deduped suggestions in `shadow`. Status line gains a `⟲` marker; `route_quota_failover` telemetry event records every switch/suggestion.
- **`/route failover`** (and `/route:failover` alias): per-member live quota with window labels, active member, and the decision that would fire right now.
- **Bug fix**: the `usage:limits` consumer now reads `windows[].percentLeft` (it previously looked for `remainingPct`, leaving provider quota permanently `unknown` to the router) and tracks `probedAt`/`windowLabel` for staleness and copy.

Primary use case wired up next: `ollama-cloud/glm-5.3-flash` → `zai/glm-5.3-flash` → `opencode-go/glm-5.3-flash`.

## Testing

- 25 new resolver/config unit tests plus 7 harness integration tests (applied switch, shadow suggestion, no-data keep, return-home + lock-state clearing, setModel failure, malformed usage payloads, `/route failover` render paths).
- Full suite green (1527 tests), lint/typecheck/mdt-check pass, 100% patch coverage.

---

Created on behalf of Ifiok Jr. (@ifiokjr), generated with Codex (openai/gpt-5.1-codex) at thinking level high.